### PR TITLE
Reveal results from GETs incrementally

### DIFF
--- a/lib/dialogs/rule.js
+++ b/lib/dialogs/rule.js
@@ -128,11 +128,9 @@ async function completeProgram(dlg, program, skipConfirmation) {
 async function drain(output) {
     for (;;) {
         let { item, resolve } = await output.next();
-        if (item.isDone) {
-            resolve();
-            return;
-        }
         resolve();
+        if (item.isDone)
+            return;
     }
 }
 
@@ -144,46 +142,49 @@ async function displayResult(dlg, app, { hasResult, autoConfirm }) {
     let count = 0;
     for (;;) {
         let { item: next, resolve, reject } = await app.mainOutput.next();
-        try {
-            if (next.isDone) {
-                resolve();
-                break;
-            }
-            if (next.isQuestion) {
+        if (next.isQuestion) {
+            try {
                 const value = await askAnything(dlg, undefined, next.icon, next.type, next.question);
                 resolve(value);
-                continue;
+            } catch(e) {
+                reject(e);
             }
-
-            anyResult = true;
-            if (count >= PAGE_SIZE) {
-                // ask the user before displaying further results
-                dlg.replySpecial(dlg._("Show more result…"), 'more');
-                try {
-                    await dlg.askMoreResults();
-                    count = 0;
-                } catch(e) {
-                    if (e.code === 'ECANCELLED') {
-                        // drain the output so that the app finishes running, otherwise
-                        // we might leave it unfinished and have to rely on GC to release its
-                        // resources
-                        await drain(app.mainOutput);
-                        break;
-                    }
-                    throw e;
-                }
-            }
-            count++;
-
-            if (next.isNotification)
-                await showNotification(dlg, undefined, next.icon, next.outputType, next.outputValue, next.currentChannel, undefined);
-            else if (next.isError)
-                await showError(dlg, undefined, next.icon, next.error, undefined);
-
-            resolve();
-        } catch(e) {
-            reject(e);
+            continue;
         }
+
+        // resolve immediately so that the program can continue and
+        // push the next result in the `app.mainOutput` queue
+        resolve();
+        if (next.isDone)
+            break;
+
+        anyResult = true;
+        if (count >= PAGE_SIZE) {
+            // ask the user before displaying further results
+            dlg.replySpecial(dlg._("Show more result…"), 'more');
+            try {
+                await dlg.askMoreResults();
+                count = 0;
+            } catch(e) {
+                if (e.code === 'ECANCELLED') {
+                    // drain the output so that the app finishes running, otherwise
+                    // we might leave it unfinished and have to rely on GC to release its
+                    // resources
+                    await drain(app.mainOutput);
+                    break;
+                }
+
+                // any other error we don't expect, so throw it to report
+                // an error message to the user and log the stack
+                throw e;
+            }
+        }
+        count++;
+
+        if (next.isNotification)
+            await showNotification(dlg, undefined, next.icon, next.outputType, next.outputValue, next.currentChannel, undefined);
+        else if (next.isError)
+            await showError(dlg, undefined, next.icon, next.error, undefined);
     }
     if (!anyResult) {
         if (hasResult)

--- a/lib/dialogs/rule.js
+++ b/lib/dialogs/rule.js
@@ -125,6 +125,74 @@ async function completeProgram(dlg, program, skipConfirmation) {
     return { ok: true, autoConfirm, hasTrigger, icon, hasResult };
 }
 
+async function drain(output) {
+    for (;;) {
+        let { item, resolve } = await output.next();
+        if (item.isDone) {
+            resolve();
+            return;
+        }
+        resolve();
+    }
+}
+
+const PAGE_SIZE = 5;
+
+async function displayResult(dlg, app, { hasResult, autoConfirm }) {
+    let anyResult = false;
+
+    let count = 0;
+    for (;;) {
+        let { item: next, resolve, reject } = await app.mainOutput.next();
+        try {
+            if (next.isDone) {
+                resolve();
+                break;
+            }
+            if (next.isQuestion) {
+                const value = await askAnything(dlg, undefined, next.icon, next.type, next.question);
+                resolve(value);
+                continue;
+            }
+
+            anyResult = true;
+            if (count >= PAGE_SIZE) {
+                // ask the user before displaying further results
+                dlg.replySpecial(dlg._("Show more result…"), 'more');
+                try {
+                    await dlg.askMoreResults();
+                    count = 0;
+                } catch(e) {
+                    if (e.code === 'ECANCELLED') {
+                        // drain the output so that the app finishes running, otherwise
+                        // we might leave it unfinished and have to rely on GC to release its
+                        // resources
+                        await drain(app.mainOutput);
+                        break;
+                    }
+                    throw e;
+                }
+            }
+            count++;
+
+            if (next.isNotification)
+                await showNotification(dlg, undefined, next.icon, next.outputType, next.outputValue, next.currentChannel, undefined);
+            else if (next.isError)
+                await showError(dlg, undefined, next.icon, next.error, undefined);
+
+            resolve();
+        } catch(e) {
+            reject(e);
+        }
+    }
+    if (!anyResult) {
+        if (hasResult)
+            dlg.reply(dlg._("Sorry, I did not find any result for that."));
+        else if (!autoConfirm)
+            dlg.done();
+    }
+}
+
 module.exports = async function ruleDialog(dlg, intent, skipConfirmation, uniqueId, sourceIdentity) {
     let source = sourceIdentity ? await getIdentityName(dlg, sourceIdentity) : null;
 
@@ -164,35 +232,5 @@ module.exports = async function ruleDialog(dlg, intent, skipConfirmation, unique
     const app = await dlg.manager.apps.loadOneApp(code, appMeta, uniqueId, undefined,
                                                   name, description, true);
 
-    // drain the queue of results from the app
-    let anyResult = false;
-    for (;;) {
-        let { item: next, resolve, reject } = await app.mainOutput.next();
-
-        try {
-            if (next.isDone) {
-                if (hasResult && !anyResult)
-                    dlg.reply(dlg._("Sorry, I did not find any result for that."));
-                resolve();
-                break;
-            }
-
-            if (next.isNotification || next.isError)
-                anyResult = true;
-
-            let value;
-            if (next.isNotification)
-                value = await showNotification(dlg, undefined, next.icon, next.outputType, next.outputValue, next.currentChannel, undefined);
-            else if (next.isError)
-                value = await showError(dlg, undefined, next.icon, next.error, undefined);
-            else if (next.isQuestion)
-                value = await askAnything(dlg, undefined, next.icon, next.type, next.question);
-            resolve(value);
-        } catch(e) {
-            reject(e);
-        }
-    }
-
-    if (!autoConfirm)
-        dlg.done();
+    await displayResult(dlg, app, { hasResult, autoConfirm });
 };

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -223,6 +223,9 @@ module.exports = class Dispatcher {
                 return intent.value;
         });
     }
+    askMoreResults() {
+        return this.expect(ValueCategory.More);
+    }
     askChoices(question, choices) {
         this.reply(question);
         this.expecting = ValueCategory.MultipleChoice;
@@ -314,11 +317,6 @@ module.exports = class Dispatcher {
         }
         if (command.isHelp && this._handleContextualHelp(command))
             return true;
-        if (command.isNeverMind) {
-            this.reset();
-            this._cancel();
-            return true;
-        }
         if (command.isWakeUp) // nothing to do
             return true;
 
@@ -330,6 +328,30 @@ module.exports = class Dispatcher {
             return this.reply(this._("No need to be sorry."));
         if (command.isThankYou)
             return this.reply(this._("At your service."));
+
+        // if we're expecting the user to click on More... or press cancel,
+        // three things can happen
+        if (this.expecting === ValueCategory.More) {
+            // if the user clicks more, more we let the intent through to rule.js
+            if (command.isMore)
+                return false;
+            // if the user says no or cancel, we inject the cancellation error but we don't show
+            // a failure message to the user
+            if (command.isNeverMind || command.isNo) {
+                this._cancel();
+                return true;
+            }
+            // if the user says anything else, we cancel the current dialog, and then let
+            // the command be injected again
+            this._cancel();
+            return false;
+        }
+
+        if (command.isNeverMind) {
+            this.reset();
+            this._cancel();
+            return true;
+        }
 
         if (this.expecting !== null &&
             (!command.isAnswer || !categoryEquals(command.category, this.expecting))) {
@@ -461,7 +483,15 @@ module.exports = class Dispatcher {
         if (handled)
             return this._mgrPromise;
 
-        assert(this._mgrPromise === null);
+        // this if statement can occur only if the user "changes the subject",
+        // in which case _handleGeneric returns false but injects a cancellation
+        // error
+        // we await this promise to make sure the stack is unwound, the cleanup
+        // code is run and we're back in the default state business
+        if (this._mgrPromise !== null) {
+            await this._mgrPromise;
+            assert(this._mgrPromise === null);
+        }
         const promise = this._waitNextIntent();
 
         if (this._isInDefaultState())

--- a/lib/semantic.js
+++ b/lib/semantic.js
@@ -32,7 +32,8 @@ const ValueCategory = adt.data({
     Contact: null,
     Predicate: null,
     PermissionResponse: null,
-    Command: null
+    Command: null,
+    More: null
 });
 
 ValueCategory.fromValue = function fromValue(value) {

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -54,6 +54,17 @@ class MockApp {
         this.mainOutput = queue;
     }
 }
+
+function genFakeData(size, fill) {
+    return String(Buffer.alloc(size, fill));
+}
+function getTestData(count, size) {
+    let ret = [];
+    for (let i = 0; i < count; i++)
+        ret.push({ data: genFakeData(size, '!'.charCodeAt(0) + i) });
+    return ret;
+}
+
 function loadOneApp(code) {
     app = code;
     let results = [];
@@ -71,6 +82,9 @@ function loadOneApp(code) {
     now => @org.thingpedia.weather(id="org.thingpedia.weather-14").current(location=makeLocation(90, 0, "North pole")) => notify;
 }`) {
         results = [{ isError: true, icon: 'org.thingpedia.weather', error: new Error('I do not like that location') }];
+    } else if (code.indexOf('@org.thingpedia.builtin.test') >= 0) {
+        results = getTestData(25, 10).map((r) => ({ isNotification: true, icon: 'org.thingpedia.builtin.test',
+            outputType: 'org.thingpedia.builtin.test:get_data', outputValue: r }));
     }
 
     return Promise.resolve(new MockApp('uuid-' + appid++, results));
@@ -2166,6 +2180,140 @@ remote mock-account:MOCK1234-phone:+1234567890/phone:+15555555555 : uuid-XXXXXX 
 `,
     null],
 
+    [
+    {code: ['now', '=>', '@org.thingpedia.builtin.test.get_data', 'param:size:Measure(byte)', '=', 'NUMBER_0',
+     'unit:byte', 'param:count:Number', '=', 'NUMBER_1', '=>', 'notify'],
+     entities: { NUMBER_1: 25, NUMBER_0: 10 } },
+`>> !!!!!!!!!!
+>> """"""""""
+>> ##########
+>> $$$$$$$$$$
+>> %%%%%%%%%%
+>> button: Show more result… {"code":["bookkeeping","special","special:more"],"entities":{}}
+>> ask special generic
+`,
+    {"code":["bookkeeping","special","special:more"],"entities":{}},
+`>> &&&&&&&&&&
+>> ''''''''''
+>> ((((((((((
+>> ))))))))))
+>> **********
+>> button: Show more result… {"code":["bookkeeping","special","special:more"],"entities":{}}
+>> ask special generic
+`,
+    {"code":["bookkeeping","special","special:more"],"entities":{}},
+`>> ++++++++++
+>> ,,,,,,,,,,
+>> ----------
+>> ..........
+>> //////////
+>> button: Show more result… {"code":["bookkeeping","special","special:more"],"entities":{}}
+>> ask special generic
+`,
+    {"code":["bookkeeping","special","special:more"],"entities":{}},
+`>> 0000000000
+>> 1111111111
+>> 2222222222
+>> 3333333333
+>> 4444444444
+>> button: Show more result… {"code":["bookkeeping","special","special:more"],"entities":{}}
+>> ask special generic
+`,
+    {"code":["bookkeeping","special","special:more"],"entities":{}},
+`>> 5555555555
+>> 6666666666
+>> 7777777777
+>> 8888888888
+>> 9999999999
+>> ask special null
+`,
+    `{
+    now => @org.thingpedia.builtin.test(id="org.thingpedia.builtin.test-27").get_data(size=10byte, count=25) => notify;
+}`],
+
+    [
+    {code: ['now', '=>', '@org.thingpedia.builtin.test.get_data', 'param:size:Measure(byte)', '=', 'NUMBER_0',
+     'unit:byte', 'param:count:Number', '=', 'NUMBER_1', '=>', 'notify'],
+     entities: { NUMBER_1: 25, NUMBER_0: 10 } },
+`>> !!!!!!!!!!
+>> """"""""""
+>> ##########
+>> $$$$$$$$$$
+>> %%%%%%%%%%
+>> button: Show more result… {"code":["bookkeeping","special","special:more"],"entities":{}}
+>> ask special generic
+`,
+    {"code":["bookkeeping","special","special:nevermind"],"entities":{}},
+`>> ask special null
+`,
+    `{
+    now => @org.thingpedia.builtin.test(id="org.thingpedia.builtin.test-28").get_data(size=10byte, count=25) => notify;
+}`],
+
+    [
+    {code: ['now', '=>', '@org.thingpedia.builtin.test.get_data', 'param:size:Measure(byte)', '=', 'NUMBER_0',
+     'unit:byte', 'param:count:Number', '=', 'NUMBER_1', '=>', 'notify'],
+     entities: { NUMBER_1: 25, NUMBER_0: 10 } },
+`>> !!!!!!!!!!
+>> """"""""""
+>> ##########
+>> $$$$$$$$$$
+>> %%%%%%%%%%
+>> button: Show more result… {"code":["bookkeeping","special","special:more"],"entities":{}}
+>> ask special generic
+`,
+    ['now', '=>', '@com.xkcd.get_comic', '=>', 'notify'],
+`>> ask special null
+>> Sorry, I did not find any result for that.
+>> ask special null
+`,
+    `{
+    now => @com.xkcd(id="com.xkcd-30").get_comic() => notify;
+}`],
+
+    [
+    {code: ['now', '=>', '@org.thingpedia.builtin.test.get_data', 'param:size:Measure(byte)', '=', 'NUMBER_0',
+     'unit:byte', 'param:count:Number', '=', 'NUMBER_1', '=>', 'notify'],
+     entities: { NUMBER_1: 25, NUMBER_0: 10 } },
+`>> !!!!!!!!!!
+>> """"""""""
+>> ##########
+>> $$$$$$$$$$
+>> %%%%%%%%%%
+>> button: Show more result… {"code":["bookkeeping","special","special:more"],"entities":{}}
+>> ask special generic
+`,
+    ['now', '=>', '@com.twitter.post'],
+`>> ask special null
+>> You have multiple Twitter devices. Which one do you want to use?
+>> choice 0: Twitter Account foo
+>> choice 1: Twitter Account bar
+>> ask special choice
+`,
+    ['bookkeeping', 'special', 'special:nevermind'],
+`>> Sorry I couldn't help on that.
+>> ask special null
+`,
+    `{
+    now => @org.thingpedia.builtin.test(id="org.thingpedia.builtin.test-31").get_data(size=10byte, count=25) => notify;
+}`],
+
+    [
+    ['now', '=>', '@com.twitter.post'],
+`>> You have multiple Twitter devices. Which one do you want to use?
+>> choice 0: Twitter Account foo
+>> choice 1: Twitter Account bar
+>> ask special choice
+`,
+    ['now', '=>', '@com.xkcd.get_comic', '=>', 'notify'],
+`>> ask special null
+>> Sorry, I did not find any result for that.
+>> ask special null
+`,
+    `{
+    now => @com.xkcd(id="com.xkcd-32").get_comic() => notify;
+}`],
+
     [(almond) => {
     almond._engine.permissions = null;
     almond._engine.remote = null;
@@ -2189,7 +2337,7 @@ remote mock-account:MOCK1234-phone:+1234567890/phone:+15555555555 : uuid-XXXXXX 
 >> ask special null
 `,
 `{
-    now => @com.xkcd(id="com.xkcd-27").get_comic() => notify;
+    now => @com.xkcd(id="com.xkcd-33").get_comic() => notify;
 }`
     ],
 

--- a/test/org.thingpedia.builtin.test.json
+++ b/test/org.thingpedia.builtin.test.json
@@ -1,0 +1,103 @@
+{
+    "module_type": "org.thingpedia.builtin",
+    "params": {},
+    "category": "system",
+    "subcategory": "service",
+    "types": [],
+    "child_types": [],
+    "auth": {
+        "type": "builtin"
+    },
+    "queries": {
+        "get_data": {
+            "args": [
+                {
+                    "name": "size",
+                    "type": "Measure(byte)",
+                    "question": "How much fake data do you want?",
+                    "is_input": true,
+                    "required": true
+                },
+                {
+                    "name": "count",
+                    "type": "Number",
+                    "question": "",
+                    "is_input": true,
+                    "required": false
+                },
+                {
+                    "name": "data",
+                    "type": "String",
+                    "question": "",
+                    "is_input": false,
+                    "required": false
+                }
+            ],
+            "doc": "generate `size` amount of fake data",
+            "confirmation": "generate $size of fake data",
+            "confirmation_remote": "generate $size of fake data on $__person's Almond",
+            "canonical": "get data on test",
+            "formatted": [
+                {
+                    "type": "text",
+                    "text": "${data}"
+                }
+            ],
+            "poll_interval": 0,
+            "is_list": true
+        },
+        "dup_data": {
+            "args": [
+                {
+                    "name": "data_in",
+                    "type": "String",
+                    "question": "What data do you want to duplicate?",
+                    "is_input": true,
+                    "required": true
+                },
+                {
+                    "name": "data_out",
+                    "type": "String",
+                    "question": "",
+                    "is_input": false,
+                    "required": false
+                }
+            ],
+            "doc": "duplicate the data (concatenate two copies); this is a simple deterministic get that depends on the input and is used to test param passing into a get",
+            "confirmation": "duplicate ${data_in} data",
+            "confirmation_remote": "",
+            "canonical": "duplicate data on test",
+            "formatted": [
+                {
+                    "type": "text",
+                    "text": "${data_out}"
+                }
+            ],
+            "poll_interval": -1,
+            "is_list": false
+        }
+    },
+    "actions": {
+        "eat_data": {
+            "args": [
+                {
+                    "name": "data",
+                    "type": "String",
+                    "question": "What do you want me to consume?",
+                    "is_input": true,
+                    "required": true
+                }
+            ],
+            "doc": "consume some data, do nothing",
+            "confirmation": "consume $data",
+            "confirmation_remote": "consume $data on $__person's Almond",
+            "canonical": "eat data on test",
+            "formatted": [],
+            "poll_interval": -1,
+            "is_list": false
+        }
+    },
+    "examples": [],
+    "version": 7,
+    "developer": false
+}


### PR DESCRIPTION
If an app produces more than 5 results, have the user click on
a More... button before the remaining results are revealed, to
avoid flooding him.

Fixes #17