### PR TITLE
Allow running in an environment without comma

### DIFF
--- a/lib/dialogs/permission_grant.js
+++ b/lib/dialogs/permission_grant.js
@@ -9,6 +9,7 @@
 // See COPYING for details
 "use strict";
 
+const assert = require('assert');
 const ThingTalk = require('thingtalk');
 const Ast = ThingTalk.Ast;
 const Describe = ThingTalk.Describe;
@@ -156,6 +157,9 @@ async function addFilter(dlg, rule) {
 }
 
 module.exports = async function permissionGrant(dlg, program, principal, identity) {
+    // if we get here, there must be a permission manager that requires an interactive grant
+    assert(dlg.manager.permissions !== null);
+
     const sourceContact = Ast.Value.Entity(identity, 'tt:contact', null);
     await addDisplayToContact(dlg, sourceContact);
     let contactName = sourceContact.display;

--- a/lib/dialogs/permission_rule.js
+++ b/lib/dialogs/permission_rule.js
@@ -16,6 +16,11 @@ const ValueCategory = require('../semantic').ValueCategory;
 const { slotFillProgram } = require('./slot_filling');
 
 module.exports = async function permissionRule(dlg, intent) {
+    if (dlg.manager.permissions === null) {
+        dlg.reply("Sorry, this version of Almond does not support adding permissions.");
+        return;
+    }
+
     const permissionRule = intent.rule;
 
     // compute primitive list

--- a/lib/dialogs/setup.js
+++ b/lib/dialogs/setup.js
@@ -21,6 +21,11 @@ const { slotFillProgram } = require('./slot_filling');
 const { ensureMessagingConfigured } = require('./messaging');
 
 module.exports = async function setupDialog(dlg, intent) {
+    if (dlg.manager.remote === null) {
+        dlg.reply("Sorry, this version of Almond does not support asking other users for permission.");
+        return;
+    }
+
     await ensureMessagingConfigured(dlg);
 
     let program = intent.program;

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -2164,7 +2164,34 @@ remote mock-account:MOCK1234-phone:+1234567890/phone:+15555555555 : uuid-XXXXXX 
 `>> Sorry, I cannot find any Cryptocurrency Code matching “invalid”
 >> ask special null
 `,
-    null]
+    null],
+
+    [(almond) => {
+    almond._engine.permissions = null;
+    almond._engine.remote = null;
+    return almond.handleParsedCommand({ program: `true : @com.xkcd.get_comic => notify;` });
+},
+`>> Sorry, this version of Almond does not support adding permissions.
+>> ask special null
+`,
+    null
+    ],
+
+    [{program: `executor = "bob"^^tt:username : now => @com.xkcd.get_comic() => notify;` },
+`>> Sorry, this version of Almond does not support asking other users for permission.
+>> ask special null
+`,
+    null
+    ],
+
+    [{program: `now => @com.xkcd.get_comic() => notify;` },
+`>> Sorry, I did not find any result for that.
+>> ask special null
+`,
+`{
+    now => @com.xkcd(id="com.xkcd-27").get_comic() => notify;
+}`
+    ],
 
 ];
 


### PR DESCRIPTION
I want to disable comma on Android (due to cvc4 being broken there), but this requires the dialog-agent not crashing if given a policy of setup command.