### PR TITLE
init dialog: remove quotes from example commands

### DIFF
--- a/lib/dialogs/init.js
+++ b/lib/dialogs/init.js
@@ -31,7 +31,7 @@ module.exports = async function initDialog(dlg, showWelcome, forceConfigureMatri
                         entities: {
                             "LOCATION_0": {"latitude": 37.7792808, "longitude": -122.4192363, "display": "San Francisco, San Francisco City and County, California, United States of America"}
                         } } },
-            { utterance: 'search "almond recipes" on YouTube',
+            { utterance: 'search almond recipes on YouTube',
               target: { code: ('now => @com.youtube.search_videos param:query:String = QUOTED_STRING_0 => notify').split(' '),
                         entities: { QUOTED_STRING_0: 'almond recipes' } } },
             { utterance: 'translate a sentence to Chinese',


### PR DESCRIPTION
Quotes are no longer needed, and in fact they don't work as
well as before