### PR TITLE
Switch away from getDeviceSetup2

### DIFF
--- a/lib/dialogs/config.js
+++ b/lib/dialogs/config.js
@@ -54,7 +54,7 @@ module.exports = async function configDialog(dlg, kind) {
         return;
     }
 
-    let factories = await dlg.manager.thingpedia.getDeviceSetup2([kind]);
+    let factories = await dlg.manager.thingpedia.getDeviceSetup([kind]);
     let factory = factories[kind];
     if (!factory) {
         dlg.reply(dlg._("I'm sorry, I can't find %s in my database.").format(Helpers.cleanKind(kind)));

--- a/lib/dialogs/device_choice.js
+++ b/lib/dialogs/device_choice.js
@@ -13,7 +13,7 @@ const Helpers = require('../helpers');
 const DiscoveryDelegate = require('./discovery_delegate');
 
 function promptConfigure(dlg, kind) {
-    return dlg.manager.thingpedia.getDeviceSetup2([kind]).then((factories) => {
+    return dlg.manager.thingpedia.getDeviceSetup([kind]).then((factories) => {
         var factory = factories[kind];
         if (!factory) {
             // something funky happened or thingpedia did not recognize the kind

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -2658,7 +2658,7 @@ function main() {
         writeLine('Clicked example ' + ex);
         return Promise.resolve();
     };
-    engine.thingpedia.getDeviceSetup2 = (kinds) => {
+    engine.thingpedia.getDeviceSetup = (kinds) => {
         var ret = {};
         for (var k of kinds) {
             if (k === 'messaging' || k === 'org.thingpedia.builtin.matrix')

--- a/test/http_client.js
+++ b/test/http_client.js
@@ -85,12 +85,8 @@ module.exports = class ThingpediaClientHttp {
         return this._simpleRequest('/api/devices', params);
     }
 
-    getDeviceSetup2(kinds) {
-        return this._simpleRequest('/api/v2/devices/setup/' + kinds.join(','));
-    }
-
     getDeviceSetup(kinds) {
-        return this._simpleRequest('/api/devices/setup/' + kinds.join(','));
+        return this._simpleRequest('/api/v2/devices/setup/' + kinds.join(','));
     }
 
     getKindByDiscovery(publicData) {

--- a/test/test_parser.js
+++ b/test/test_parser.js
@@ -62,7 +62,7 @@ function candidateToString(cand) {
     else if (cand.isSetup)
         return `Setup(${cand.program.prettyprint(true)})`;
     else if (cand.isPermissionRule)
-        return `PermissionRule(${cand.permissionRule.prettyprint(true)})`;
+        return `PermissionRule(${cand.rule.prettyprint(true)})`;
     else
         return String(cand);
 }


### PR DESCRIPTION
Use getDeviceSetup, under the assumption it calls the newer
version of the API.

This assumption will become true when we switch to the thingpedia-client
library instead of using the client provided by thingengine-core.