### PR TITLE
Skip exact matches that fail to parse because unsupported

### DIFF
--- a/lib/almond.js
+++ b/lib/almond.js
@@ -212,24 +212,34 @@ module.exports = class Almond extends events.EventEmitter {
             console.log('Analyzed message into ' + analyzed.candidates[0].code.join(' '));
         else
             console.log('Failed to analyze message');
-        return Promise.all(analyzed.candidates.map((candidate, beamposition) => {
-            return Intent.parse({ code: candidate.code, entities: analyzed.entities }, this.schemas, analyzed, this._lastCommand, this._lastCandidates).catch((e) => {
+        return Promise.all(analyzed.candidates.map(async (candidate, beamposition) => {
+            let parsed;
+            try {
+                parsed = await Intent.parse({ code: candidate.code, entities: analyzed.entities }, this.schemas, analyzed, this._lastCommand, this._lastCandidates);
+            } catch(e) {
                 // Likely, a type error in the ThingTalk code; not a big deal, but we still log it
                 console.log(`Failed to parse beam ${beamposition}: ${e.message}`);
 
                 if (this._isUnsupportedError(e))
-                    return Intent.Unsupported;
-                return null;
-            });
+                    parsed = Intent.Unsupported;
+                else
+                    return null;
+            }
+            return { target: parsed, score: candidate.score };
         })).then((candidates) => candidates.filter((c) => c !== null)).then((candidates) => {
             // here we used to do a complex heuristic dance of probabilities and confidence scores
             // we do none of that, because Almond-NNParser does not give us useful scores
 
             if (candidates.length > 0) {
-                let choice = candidates[0];
+                let i = 0;
+                let choice = candidates[i];
+                while (i < candidates.length-1 && choice.target.isUnsupported && choice.score === 'Infinity') {
+                    i++;
+                    choice = candidates[i];
+                }
 
                 this.stats.hit('sabrina-command-good');
-                return this._doHandleCommand(choice, analyzed, analyzed.candidates);
+                return this._doHandleCommand(choice.target, analyzed, analyzed.candidates);
             } else {
                 this._lastCommand = analyzed;
                 this._lastCandidates = candidates;

--- a/lib/dialogs/fallback.js
+++ b/lib/dialogs/fallback.js
@@ -80,26 +80,20 @@ async function failWithFallbacks(dlg, command, fallbacks) {
     } else {
         let choices = [];
         let prev = null;
-        let prevCanonical = null;
+        let seenCanonicals = new Set;
         for (let i = 0; i < canonicals.length; i++) {
             if (canonicals[i] === null)
                 continue;
             if (fallbacks[i] === prev)
                 continue;
-            if (canonicals[i] === prevCanonical) {
-                // this happens sometimes because we map different JSON forms to the
-                // same Intent configuration, eg "list queries" and "list commands"
-                // or "discover hue" and "configure hue"
-                // all these are bugs and should be resolved in the grammar, but no need
-                // to show them off
-                console.error('Canonical is equal to prev canonical');
-                console.error('Previous was ' + prev);
-                console.error('Current is ' + fallbacks[i]);
+            if (seenCanonicals.has(canonicals[i])) {
+                // this happens sometimes due to the exact matcher duplicating
+                // some results from the regular matcher, ignore it
                 continue;
             }
+            seenCanonicals.add(canonicals[i]);
             choices.push([fallbacks[i], canonicals[i]]);
             prev = fallbacks[i];
-            prevCanonical = canonicals[i];
         }
         choices.push([null, dlg._("none of the above")]);
 


### PR DESCRIPTION
If you go on Try Almond, and type the exact phrase "get articles in the new york times", you get "Sorry, I don't know how to do that yet.", because a developer has added it to their own testing copy of the NYT (following the tutorial).
This is wrong.