### PR TITLE
Add customizable hooks for permissions & logging

### DIFF
--- a/lib/almond.js
+++ b/lib/almond.js
@@ -25,13 +25,56 @@ const DEFAULT_GETTEXT = {
     dpgettext: (domain, ctx, msg) => msg,
 };
 
+function apiCompat(user, manager) {
+    if (user.principal === undefined)
+        user.principal = user.speakerId ? 'speaker:' + user.speakerId : 'user:' + user.id;
+
+    if (user.isOwner === undefined)
+        user.isOwner = true;
+    if (user.canConfigureDevice === undefined)
+        user.canConfigureDevice = function() { return this.isOwner; };
+    if (user.canCreatePermissionRule === undefined)
+        user.canCreatePermissionRule = function() { return this.isOwner; };
+    if (user.canExecute === undefined) {
+        user.canExecute = async function(program) {
+            if (this.isOwner)
+                return true;
+            if (program.principal) // never allow remote execution
+                return false;
+
+            // check for permission without modifying the program (quick check on incomplete programs)
+            return manager.permissions.checkCanBeAllowed(this.principal, program);
+        };
+    }
+    if (user.applyPermissionRules === undefined) {
+        user.applyPermissionRules = async function(program) {
+            if (this.isOwner)
+                return program;
+            if (program.principal) // never allow remote execution
+                return null;
+
+            // check for permission and potentially modify the program
+            return manager.permissions.checkIsAllowed(this.principal, program);
+        };
+    }
+
+    // hooks to modify the program/policy (eg add a filter/condition to restrict to data of a certain user)
+    // after confirmation but before calling to thingengine-core
+    // for remote programs (if supported), this is called before lowering
+    if (user.adjustAndLogProgram === undefined)
+        user.adjustAndLogProgram = async function(program, description) { return [program, description]; };
+    if (user.adjustAndLogPermissionRule === undefined)
+        user.adjustAndLogPermissionRule = async function(policy, description) { return [policy, description]; };
+}
+
 module.exports = class Almond extends events.EventEmitter {
     constructor(engine, conversationId, user, delegate, options) {
         super();
         this._engine = engine;
         this._user = user;
-        if (this._user.isOwner === undefined)
-            this._user.isOwner = true; // API compat
+
+        // API compat
+        apiCompat(user, this);
 
         this._conversationId = conversationId;
         this._gettext = this._engine.platform.getCapability('gettext');

--- a/lib/dialogs/config.js
+++ b/lib/dialogs/config.js
@@ -53,6 +53,10 @@ module.exports = async function configDialog(dlg, kind) {
         dlg.replyLink(dlg._("Register for Almond"), "/user/register");
         return;
     }
+    if (!dlg.manager.user.canConfigureDevice(kind)) {
+        dlg.forbid();
+        return;
+    }
 
     let factories = await dlg.manager.thingpedia.getDeviceSetup([kind]);
     let factory = factories[kind];

--- a/lib/dialogs/device_choice.js
+++ b/lib/dialogs/device_choice.js
@@ -30,6 +30,10 @@ function promptConfigure(dlg, kind) {
                 dlg.replyLink(dlg._("Register for Almond"), "/user/register");
                 return null;
             }
+            if (!dlg.manager.user.canConfigureDevice(kind)) {
+                dlg.reply(dlg._("%s is not configured. You must ask the administrator of this Almond to enable it before using it.").format(factory.text || Helpers.cleanKind(kind)));
+                return null;
+            }
 
             if (factory.type === 'interactive') {
                 const delegate = new DiscoveryDelegate(dlg, factory.category);

--- a/lib/dialogs/discovery.js
+++ b/lib/dialogs/discovery.js
@@ -35,6 +35,10 @@ module.exports = async function discoveryDialog(dlg, discoveryType, discoveryKin
         dlg.replyLink(dlg._("Register for Almond"), "/user/register");
         return;
     }
+    if (!dlg.manager.user.canConfigureDevice(null)) {
+        dlg.forbid();
+        return;
+    }
 
     let devices;
     try {

--- a/lib/dialogs/permission_rule.js
+++ b/lib/dialogs/permission_rule.js
@@ -21,14 +21,14 @@ module.exports = async function permissionRule(dlg, intent) {
         return;
     }
 
-    const permissionRule = intent.rule;
+    let permissionRule = intent.rule;
 
-    if (!dlg.manager.user.isOwner) {
-        dlg.reply(dlg._("I'm sorry, only my owner can change my permissions."));
-        return;
-    }
     if (dlg.manager.isAnonymous) {
         dlg.reply(dlg._("This user is a demo only; you cannot change the permissions on it."));
+        return;
+    }
+    if (!dlg.manager.user.canCreatePermissionRule(permissionRule)) {
+        dlg.forbid();
         return;
     }
 
@@ -62,8 +62,11 @@ module.exports = async function permissionRule(dlg, intent) {
         dlg.reset();
         return;
     }
-
     dlg.manager.stats.hit('sabrina-confirm');
+
+    // describe the permission rule again to store it in the database
+    [permissionRule, description] = await dlg.manager.user.adjustAndLogPermissionRule(permissionRule, description);
+
     await dlg.manager.permissions.addPermission(permissionRule, description);
     dlg.done();
 };

--- a/lib/dialogs/rule.js
+++ b/lib/dialogs/rule.js
@@ -201,15 +201,12 @@ module.exports = async function ruleDialog(dlg, intent, skipConfirmation, unique
     assert(program.isProgram);
     dlg.debug('About to execute program', program.prettyprint());
 
-    if (!dlg.manager.user.isOwner) {
-        // check for permission on the incomplete program first
-        // this is an incomplete check, but we do it early before
-        // asking questions to the user
-        const principal = 'speaker:' + dlg.manager.user.speakerId;
-        if (!await dlg.manager.permissions.checkCanBeAllowed(principal, program)) {
-            dlg.reply(dlg._("I'm sorry, you don't have permission to do that."));
-            return;
-        }
+    // check for permission on the incomplete program first
+    // this is an incomplete check, but we do it early before
+    // asking questions to the user
+    if (!await dlg.manager.user.canExecute(program)) {
+        dlg.forbid();
+        return;
     }
 
     dlg.icon = null;
@@ -217,15 +214,10 @@ module.exports = async function ruleDialog(dlg, intent, skipConfirmation, unique
     if (!ok)
         return;
 
-    if (!dlg.manager.user.isOwner) {
-        // check for permission and potentially modify the program
-        const principal = 'speaker:' + dlg.manager.user.speakerId;
-
-        program = await dlg.manager.permissions.checkIsAllowed(principal, program);
-        if (program === null) {
-            dlg.reply(dlg._("I'm sorry, you don't have permission to do that."));
-            return;
-        }
+    program = await dlg.manager.user.applyPermissionRules(program);
+    if (program === null) {
+        dlg.forbid();
+        return;
     }
 
     let name = Describe.getProgramName(dlg.manager.gettext, program);
@@ -250,6 +242,8 @@ module.exports = async function ruleDialog(dlg, intent, skipConfirmation, unique
         else
             dlg.reply(dlg._("Ok, I'm going to %s.").format(description));
     }
+
+    [program, description] = await dlg.manager.user.adjustAndLogProgram(program, description);
 
     const code = program.prettyprint();
     const app = await dlg.manager.apps.loadOneApp(code, appMeta, uniqueId, undefined,

--- a/lib/dialogs/setup.js
+++ b/lib/dialogs/setup.js
@@ -30,20 +30,23 @@ module.exports = async function setupDialog(dlg, intent) {
         dlg.replyLink(dlg._("Register for Almond"), "/user/register");
         return;
     }
-    if (!dlg.manager.user.isOwner) {
-        dlg.reply(dlg._("I'm sorry, only my owner can ask other users for permission."));
+
+    // check for permission on the incomplete program first
+    // this is an incomplete check, but we do it early before
+    // asking questions to the user
+    if (!await dlg.manager.user.canExecute(intent.program)) {
+        dlg.forbid();
         return;
     }
 
     await ensureMessagingConfigured(dlg);
 
-    let program = intent.program;
-    let ok = await slotFillProgram(dlg, program);
+    let ok = await slotFillProgram(dlg, intent.program);
     if (!ok)
         return;
 
     let icon = null;
-    for (let [, prim] of program.iteratePrimitives()) {
+    for (let [, prim] of intent.program.iteratePrimitives()) {
         if (prim.selector.isBuiltin)
             continue;
         let newIcon = Helpers.getIcon(prim);
@@ -51,6 +54,13 @@ module.exports = async function setupDialog(dlg, intent) {
             icon = newIcon;
     }
     dlg.icon = icon;
+
+    // apply permission rules if needed
+    let program = await dlg.manager.user.applyPermissionRules(intent.program);
+    if (program === null) {
+        dlg.forbid();
+        return;
+    }
 
     let name = Describe.getProgramName(dlg.manager.gettext, program);
     let description = Describe.describeProgram(dlg.manager.gettext, program);
@@ -60,6 +70,8 @@ module.exports = async function setupDialog(dlg, intent) {
         dlg.reset();
         return;
     }
+
+    [program,] = await dlg.manager.user.adjustAndLogProgram(program, description);
 
     const identities = dlg.manager.messaging.getIdentities();
     const identity = Helpers.findPrimaryIdentity(identities);

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -202,6 +202,9 @@ module.exports = class Dispatcher {
         return true;
     }
 
+    forbid() {
+        this.reply(this._("I'm sorry, you don't have permission to do that."));
+    }
     done() {
         this.reply(this._("Consider it done."));
     }

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -2383,7 +2383,7 @@ null],
     almond.user.isOwner = false;
     return almond.handleParsedCommand({ program: `true : * => *;` });
 },
-`>> I'm sorry, only my owner can change my permissions.
+`>> I'm sorry, you don't have permission to do that.
 >> ask special null
 `,
 null],
@@ -2392,7 +2392,7 @@ null],
     almond.user.isOwner = false;
     return almond.handleParsedCommand({ program: `executor = "bob"^^tt:username : now => @com.facebook.post(status=$undefined);` });
 },
-`>> I'm sorry, only my owner can ask other users for permission.
+`>> I'm sorry, you don't have permission to do that.
 >> ask special null
 `,
 null],


### PR DESCRIPTION
These hooks allows different platforms to provide different behavior
of how/when access control policies are applied.