### PR TITLE
Inject information about slack users

### DIFF
--- a/lib/almond.js
+++ b/lib/almond.js
@@ -212,7 +212,7 @@ module.exports = class Almond extends events.EventEmitter {
         return /(invalid kind| has no (quer(ies|y)|actions?)) /i.test(e.message);
     }
 
-    handleParsedCommand(root, plaformData = {}) {
+    handleParsedCommand(root, platformData = {}) {
         this.stats.hit('sabrina-parsed-command');
         this.emit('active');
         if (this._debug)
@@ -226,21 +226,21 @@ module.exports = class Almond extends events.EventEmitter {
         }
 
         return this._errorWrap(async () => {
-            const intent = await Intent.parse(root, this.schemas, null, this._lastCommand, this._lastCandidates, plaformData);
+            const intent = await Intent.parse(root, this.schemas, null, this._lastCommand, this._lastCandidates, platformData);
             return this._doHandleCommand(intent, null, []);
-        }, plaformData);
+        }, platformData);
     }
 
-    handleThingTalk(thingtalk, plaformData = {}) {
+    handleThingTalk(thingtalk, platformData = {}) {
         this.stats.hit('sabrina-thingtalk-command');
         this.emit('active');
         if (this._debug)
             console.log('Received ThingTalk program');
 
         return this._errorWrap(async () => {
-            const intent = await Intent.parseProgram(thingtalk, this.schemas, plaformData);
+            const intent = await Intent.parseProgram(thingtalk, this.schemas, platformData);
             return this._doHandleCommand(intent, null, []);
-        }, plaformData);
+        }, platformData);
     }
 
     _doHandleCommand(intent, analyzed, candidates) {
@@ -252,7 +252,7 @@ module.exports = class Almond extends events.EventEmitter {
         return this._dispatcher.handle(intent);
     }
 
-    _continueHandleCommand(command, analyzed, plaformData) {
+    _continueHandleCommand(command, analyzed, platformData) {
         analyzed.utterance = command;
         // parse all code sequences into an Intent
         // this will correctly filter out anything that does not parse
@@ -263,13 +263,13 @@ module.exports = class Almond extends events.EventEmitter {
         return Promise.all(analyzed.candidates.map(async (candidate, beamposition) => {
             let parsed;
             try {
-                parsed = await Intent.parse({ code: candidate.code, entities: analyzed.entities }, this.schemas, analyzed, this._lastCommand, this._lastCandidates, plaformData);
+                parsed = await Intent.parse({ code: candidate.code, entities: analyzed.entities }, this.schemas, analyzed, this._lastCommand, this._lastCandidates, platformData);
             } catch(e) {
                 // Likely, a type error in the ThingTalk code; not a big deal, but we still log it
                 console.log(`Failed to parse beam ${beamposition}: ${e.message}`);
 
                 if (this._isUnsupportedError(e))
-                    parsed = new Intent.Unsupported(plaformData);
+                    parsed = new Intent.Unsupported(platformData);
                 else
                     return null;
             }
@@ -293,18 +293,18 @@ module.exports = class Almond extends events.EventEmitter {
                 this._lastCandidates = candidates;
 
                 this.stats.hit('sabrina-failure');
-                return this._dispatcher.handle(new Intent.Failed(analyzed, plaformData));
+                return this._dispatcher.handle(new Intent.Failed(analyzed, platformData));
             }
         });
     }
 
-    async _errorWrap(fn, plaformData) {
+    async _errorWrap(fn, platformData) {
         try {
             try {
                 await fn();
             } catch(e) {
                 if (this._isUnsupportedError(e))
-                    await this._doHandleCommand(new Intent.Unsupported(plaformData), null, []);
+                    await this._doHandleCommand(new Intent.Unsupported(platformData), null, []);
                 else
                     throw e;
             }
@@ -316,7 +316,7 @@ module.exports = class Almond extends events.EventEmitter {
         }
     }
 
-    handleCommand(command, plaformData = {}, postprocess) {
+    handleCommand(command, platformData = {}, postprocess) {
         this.stats.hit('sabrina-command');
         this.emit('active');
         if (this._debug)
@@ -324,14 +324,14 @@ module.exports = class Almond extends events.EventEmitter {
 
         return this._errorWrap(async () => {
             if (this._raw && command !== null) {
-                let intent = new Intent.Answer(this._expecting, ThingTalk.Ast.Value.String(command), plaformData);
+                let intent = new Intent.Answer(this._expecting, ThingTalk.Ast.Value.String(command), platformData);
                 return this._doHandleCommand(intent, command, []);
             }
 
             const analyzed = await this.parser.sendUtterance(command, this._expecting, this._choices);
             if (postprocess)
                 postprocess(analyzed);
-            return this._continueHandleCommand(command, analyzed, plaformData);
+            return this._continueHandleCommand(command, analyzed, platformData);
         });
     }
 

--- a/lib/almond.js
+++ b/lib/almond.js
@@ -212,7 +212,7 @@ module.exports = class Almond extends events.EventEmitter {
         return /(invalid kind| has no (quer(ies|y)|actions?)) /i.test(e.message);
     }
 
-    handleParsedCommand(root) {
+    handleParsedCommand(root, plaformData = {}) {
         this.stats.hit('sabrina-parsed-command');
         this.emit('active');
         if (this._debug)
@@ -226,21 +226,21 @@ module.exports = class Almond extends events.EventEmitter {
         }
 
         return this._errorWrap(async () => {
-            const intent = await Intent.parse(root, this.schemas, null, this._lastCommand, this._lastCandidates);
+            const intent = await Intent.parse(root, this.schemas, null, this._lastCommand, this._lastCandidates, plaformData);
             return this._doHandleCommand(intent, null, []);
-        });
+        }, plaformData);
     }
 
-    handleThingTalk(thingtalk) {
+    handleThingTalk(thingtalk, plaformData = {}) {
         this.stats.hit('sabrina-thingtalk-command');
         this.emit('active');
         if (this._debug)
             console.log('Received ThingTalk program');
 
         return this._errorWrap(async () => {
-            const intent = await Intent.parseProgram(thingtalk, this.schemas);
+            const intent = await Intent.parseProgram(thingtalk, this.schemas, plaformData);
             return this._doHandleCommand(intent, null, []);
-        });
+        }, plaformData);
     }
 
     _doHandleCommand(intent, analyzed, candidates) {
@@ -252,7 +252,7 @@ module.exports = class Almond extends events.EventEmitter {
         return this._dispatcher.handle(intent);
     }
 
-    _continueHandleCommand(command, analyzed) {
+    _continueHandleCommand(command, analyzed, plaformData) {
         analyzed.utterance = command;
         // parse all code sequences into an Intent
         // this will correctly filter out anything that does not parse
@@ -263,13 +263,13 @@ module.exports = class Almond extends events.EventEmitter {
         return Promise.all(analyzed.candidates.map(async (candidate, beamposition) => {
             let parsed;
             try {
-                parsed = await Intent.parse({ code: candidate.code, entities: analyzed.entities }, this.schemas, analyzed, this._lastCommand, this._lastCandidates);
+                parsed = await Intent.parse({ code: candidate.code, entities: analyzed.entities }, this.schemas, analyzed, this._lastCommand, this._lastCandidates, plaformData);
             } catch(e) {
                 // Likely, a type error in the ThingTalk code; not a big deal, but we still log it
                 console.log(`Failed to parse beam ${beamposition}: ${e.message}`);
 
                 if (this._isUnsupportedError(e))
-                    parsed = Intent.Unsupported;
+                    parsed = new Intent.Unsupported(plaformData);
                 else
                     return null;
             }
@@ -293,18 +293,18 @@ module.exports = class Almond extends events.EventEmitter {
                 this._lastCandidates = candidates;
 
                 this.stats.hit('sabrina-failure');
-                return this._dispatcher.handle(Intent.Failed(analyzed));
+                return this._dispatcher.handle(new Intent.Failed(analyzed, plaformData));
             }
         });
     }
 
-    async _errorWrap(fn) {
+    async _errorWrap(fn, plaformData) {
         try {
             try {
                 await fn();
             } catch(e) {
                 if (this._isUnsupportedError(e))
-                    await this._doHandleCommand(Intent.Unsupported, null, []);
+                    await this._doHandleCommand(new Intent.Unsupported(plaformData), null, []);
                 else
                     throw e;
             }
@@ -316,7 +316,7 @@ module.exports = class Almond extends events.EventEmitter {
         }
     }
 
-    handleCommand(command, postprocess) {
+    handleCommand(command, plaformData = {}, postprocess) {
         this.stats.hit('sabrina-command');
         this.emit('active');
         if (this._debug)
@@ -324,14 +324,14 @@ module.exports = class Almond extends events.EventEmitter {
 
         return this._errorWrap(async () => {
             if (this._raw && command !== null) {
-                let intent = new Intent.Answer(this._expecting, ThingTalk.Ast.Value.String(command));
+                let intent = new Intent.Answer(this._expecting, ThingTalk.Ast.Value.String(command), plaformData);
                 return this._doHandleCommand(intent, command, []);
             }
 
             const analyzed = await this.parser.sendUtterance(command, this._expecting, this._choices);
             if (postprocess)
                 postprocess(analyzed);
-            return this._continueHandleCommand(command, analyzed);
+            return this._continueHandleCommand(command, analyzed, plaformData);
         });
     }
 

--- a/lib/dialogs/contact_search.js
+++ b/lib/dialogs/contact_search.js
@@ -196,6 +196,18 @@ module.exports.contactSearch = async function (dlg, type, name) {
             throw new TypeError('Invalid contact type ' + type);
     }
 
+    if (dlg.platformData.contacts) {
+        for (let platformContact of dlg.platformData.contacts) {
+            if (platformContact.value === name) {
+                console.log(`Mapped @${name} to ${platformContact.principal} using platform data`);
+                return makeValue(dlg, category, {
+                    value: platformContact.principal,
+                    displayName: platformContact.display
+                });
+            }
+        }
+    }
+
     let choices = name === null ? [] : await lookupContact(dlg, category, name);
     if (choices === null) {
         dlg.reply(dlg._("You don't have a valid address book available."));
@@ -216,11 +228,11 @@ module.exports.contactSearch = async function (dlg, type, name) {
         };
         if (category === ValueCategory.Contact)
             contact.value = 'phone:' + contact.value;
-        return await makeValue(dlg, category, contact);
+        return makeValue(dlg, category, contact);
     }
 
     if (choices.length === 1)
-        return await makeValue(dlg, category, choices[0]);
+        return makeValue(dlg, category, choices[0]);
 
     let model = new SimpleClassifier(featurizeContact.bind(null, name), SCORING_MODEL);
     let scored = model.scoreAll(choices);
@@ -245,9 +257,9 @@ module.exports.contactSearch = async function (dlg, type, name) {
     }
 
     if (choice !== null)
-        return await makeValue(dlg, category, choice);
+        return makeValue(dlg, category, choice);
 
     let idx = await dlg.askChoices(dlg._("Multiple contacts match “%s”. Who do you mean?").format(name),
         fallbacks.map((c) => c.displayName));
-    return await makeValue(dlg, category, fallbacks[idx]);
+    return makeValue(dlg, category, fallbacks[idx]);
 };

--- a/lib/dialogs/contact_search.js
+++ b/lib/dialogs/contact_search.js
@@ -134,7 +134,7 @@ function lookupMessaging(dlg, name) {
     return messaging.searchAccountByName(name).then((accounts) => {
         return accounts.map((a) => {
             return {
-                value: messaging.type + '-account:' + a.account,
+                value: a.account,
                 displayName: a.name,
                 alternativeDisplayName: a.name,
                 isPrimary: false,

--- a/lib/dialogs/default.js
+++ b/lib/dialogs/default.js
@@ -106,7 +106,7 @@ async function loop(dlg, showWelcome) {
                         value = await discoveryDialog(dlg);
                 } else if (next.isRunProgram) {
                     lastApp = undefined;
-                    value = await ruleDialog(dlg, Intent.Program(next.program), true, next.uniqueId, next.identity);
+                    value = await ruleDialog(dlg, new Intent.Program(next.program, {}), true, next.uniqueId, next.identity);
                 }
 
                 resolve(value);

--- a/lib/dialogs/make.js
+++ b/lib/dialogs/make.js
@@ -250,7 +250,7 @@ function computeDescriptions(dlg, stream, query, action) {
 const ENABLE_REMOTE_COMMANDS = false;
 const ENABLE_WHEN_GET_DO = false;
 
-module.exports = async function makeDialog(dlg) {
+module.exports = async function makeDialog(dlg, startIntent) {
     let utterances = [];
     let filterDescription = ['','',''];
     let filterCandidates = [[], []];
@@ -485,7 +485,7 @@ module.exports = async function makeDialog(dlg) {
     program = makeProgram(rule.stream, rule.query, rule.action, user);
 
     if (program.principal)
-        await setupDialog(dlg, new Intent.Setup(program.optimize()));
+        await setupDialog(dlg, new Intent.Setup(program.optimize(), startIntent.plaformData));
     else
-        await ruleDialog(dlg, new Intent.Program(program.optimize()), true);
+        await ruleDialog(dlg, new Intent.Program(program.optimize(), startIntent.plaformData), true);
 };

--- a/lib/dialogs/slot_filling.js
+++ b/lib/dialogs/slot_filling.js
@@ -24,20 +24,22 @@ const resolveUserContext = require('./user_context');
 const { chooseDevice } = require('./device_choice');
 const { lookupEntity } = require('./entity_lookup');
 
+const MESSAGING_ACCOUNT_REGEX = /^[A-Za-z.0-9]+-account:/;
+
 async function addDisplayToContact(dlg, contact) {
     const principal = contact.value;
-    if (principal.startsWith(dlg.manager.messaging.type + '-account:')) {
-        if (principal === dlg.manager.messaging.type + '-account:' + dlg.manager.messaging.account) {
+
+    if (MESSAGING_ACCOUNT_REGEX.test(principal)) {
+        if (dlg.manager.messaging.isSelf(principal)) {
             contact.display = dlg._("me");
             return;
         }
 
-        const account = principal.substr((dlg.manager.messaging.type + '-account:').length);
         try {
-            const user = await dlg.manager.messaging.getUserByAccount(account);
+            const user = await dlg.manager.messaging.getUserByAccount(principal);
             contact.display = user.name;
         } catch (e) {
-            console.log('Failed to lookup account ' + account + ': ' + e.message);
+            console.log('Failed to lookup account ' + principal + ': ' + e.message);
         }
     } else {
         const contactApi = dlg.manager.platform.getCapability('contacts');
@@ -75,7 +77,7 @@ async function maybeAddDisplayToValue(dlg, value) {
 
 async function lookupContact(dlg, contact) {
     let principal = contact.value;
-    if (principal.startsWith(dlg.manager.messaging.type + '-account:'))
+    if (MESSAGING_ACCOUNT_REGEX.test(principal))
         return true;
     if (principal.startsWith('speaker:'))
         return true;
@@ -83,9 +85,8 @@ async function lookupContact(dlg, contact) {
     try {
         const account = await dlg.manager.messaging.getAccountForIdentity(principal);
         if (account) {
-            var accountPrincipal = dlg.manager.messaging.type + '-account:' + account;
-            console.log('Converted ' + contact.value + ' to ' + accountPrincipal);
-            contact.value = accountPrincipal;
+            console.log('Converted ' + contact.value + ' to ' + account);
+            contact.value = account;
             return true;
         } else {
             dlg.reply(dlg._("Cannot find a messaging account for %s.").format(contact.display || principal));

--- a/lib/dialogs/slot_filling.js
+++ b/lib/dialogs/slot_filling.js
@@ -29,6 +29,15 @@ const MESSAGING_ACCOUNT_REGEX = /^[A-Za-z.0-9]+-account:/;
 async function addDisplayToContact(dlg, contact) {
     const principal = contact.value;
 
+    if (dlg.platformData.contacts) {
+        for (let platformContact of dlg.platformData.contacts) {
+            if (platformContact.principal === principal) {
+                contact.display = platformContact.display;
+                return;
+            }
+        }
+    }
+
     if (MESSAGING_ACCOUNT_REGEX.test(principal)) {
         if (dlg.manager.messaging.isSelf(principal)) {
             contact.display = dlg._("me");

--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -81,6 +81,7 @@ module.exports = class Dispatcher {
         this.formatter = new ThingTalk.Formatter(manager.platform.locale, manager.platform.timezone, manager.schemas, manager.gettext);
         this.icon = null;
         this.expecting = null;
+        this.platformData = null;
         this._choices = null;
 
         this._mgrResolve = null;
@@ -103,18 +104,25 @@ module.exports = class Dispatcher {
         console.log.apply(console, arguments);
     }
 
-    nextIntent() {
+    async nextIntent() {
         this._mgrPromise = null;
         this._mgrResolve();
-        return this._userInputQueue.pop();
+        const intent = await this._userInputQueue.pop();
+        this.platformData = intent.platformData;
+        return intent;
     }
-    nextQueueItem() {
+    async nextQueueItem() {
         this.expecting = null;
         this.manager.expect(null);
         this.manager.sendAskSpecial();
         this._mgrPromise = null;
         this._mgrResolve();
-        return this._notifyQueue.pop();
+        const queueItem = await this._notifyQueue.pop();
+        if (queueItem.item.isUserInput)
+            this.platformData = queueItem.item.intent.platformData;
+        else
+            this.platformData = {};
+        return queueItem;
     }
 
     unexpected() {

--- a/lib/semantic.js
+++ b/lib/semantic.js
@@ -109,43 +109,47 @@ ValueCategory.toAskSpecial = function toAskSpecial(expected) {
 
 const Intent = adt.data({
     // internally generated intents
-    Failed: { command: adt.only(Object, null) },
-    Train: { command: adt.only(Object, null), fallbacks: adt.only(Array, null) },
-    Back: null,
-    More: null,
-    Empty: null,
-    Debug: null,
-    Maybe: null,
-    Unsupported: null,
-    Example: { utterance: adt.only(String), targetCode: adt.only(String) },
-    CommandList: { device: adt.only(String, null), category: adt.only(String) },
+    Failed: { command: adt.only(Object, null), plaformData: adt.any },
+    Train: { command: adt.only(Object, null), fallbacks: adt.only(Array, null), plaformData: adt.any },
+    Back: { plaformData: adt.any },
+    More: { plaformData: adt.any },
+    Empty: { plaformData: adt.any },
+    Debug: { plaformData: adt.any },
+    Maybe: { plaformData: adt.any },
+    Unsupported: { plaformData: adt.any },
+    Example: { utterance: adt.only(String), targetCode: adt.only(String), plaformData: adt.any },
+    CommandList: { device: adt.only(String, null), category: adt.only(String), plaformData: adt.any },
 
     // special entries in the grammar
-    NeverMind: null, // cancel the current task
-    Help: null, // ask for contextual help, or start a new task
-    Make: null, // reset and start a new task
-    WakeUp: null, // do nothing and wake up the screen
+    NeverMind: { plaformData: adt.any }, // cancel the current task
+    Help: { plaformData: adt.any }, // ask for contextual help, or start a new task
+    Make: { plaformData: adt.any }, // reset and start a new task
+    WakeUp: { plaformData: adt.any }, // do nothing and wake up the screen
 
     // easter eggs
-    Hello: null,
-    Cool: null,
-    ThankYou: null,
-    Sorry: null,
+    Hello: { plaformData: adt.any },
+    Cool: { plaformData: adt.any },
+    ThankYou: { plaformData: adt.any },
+    Sorry: { plaformData: adt.any },
 
-    Answer: { category: adt.only(ValueCategory), value: adt.only(Ast.Value, Number) },
+    Answer: { category: adt.only(ValueCategory), value: adt.only(Ast.Value, Number), plaformData: adt.any },
 
     // thingtalk
     Program: {
-        program: adt.only(Ast.Program)
+        program: adt.only(Ast.Program),
+        plaformData: adt.any
     },
     Predicate: {
-        predicate: adt.only(Ast.BooleanExpression)
+        predicate: adt.only(Ast.BooleanExpression),
+        plaformData: adt.any
     },
     Setup: {
-        program: adt.only(Ast.Program)
+        program: adt.only(Ast.Program),
+        plaformData: adt.any
     },
     PermissionRule: {
-        rule: adt.only(Ast.PermissionRule)
+        rule: adt.only(Ast.PermissionRule),
+        plaformData: adt.any
     }
 });
 
@@ -166,63 +170,63 @@ const SPECIAL_INTENT_MAP = {
     wakeup: Intent.WakeUp,
 };
 
-function parseSpecial(special, command, previousCommand, previousCandidates) {
+function parseSpecial(special, command, previousCommand, previousCandidates, plaformData) {
     let intent;
     special = special.substring('special:'.length);
     switch (special) {
     case 'yes':
-        intent = new Intent.Answer(ValueCategory.YesNo, Ast.Value.Boolean(true));
+        intent = new Intent.Answer(ValueCategory.YesNo, Ast.Value.Boolean(true), plaformData);
         intent.isYes = true;
         intent.isNo = false;
         break;
     case 'no':
-        intent = new Intent.Answer(ValueCategory.YesNo, Ast.Value.Boolean(false));
+        intent = new Intent.Answer(ValueCategory.YesNo, Ast.Value.Boolean(false), plaformData);
         intent.isYes = false;
         intent.isNo = true;
         break;
     case 'failed':
-        intent = new Intent.Failed(command);
+        intent = new Intent.Failed(command, plaformData);
         break;
     case 'train':
-        intent = new Intent.Train(previousCommand, previousCandidates);
+        intent = new Intent.Train(previousCommand, previousCandidates, plaformData);
         break;
     default:
         if (!SPECIAL_INTENT_MAP[special])
             throw new Error('Unrecognized special ' + special);
-        intent = SPECIAL_INTENT_MAP[special];
+        intent = new (SPECIAL_INTENT_MAP[special])(plaformData);
     }
     return intent;
 }
 
-function parseBookeeping(code, schemaRetriever, entities, command, previousCommand, previousCandidates) {
+function parseBookeeping(code, schemaRetriever, entities, command, previousCommand, previousCandidates, plaformData) {
     switch (code[1]) {
     case 'special':
-        return parseSpecial(code[2], command, previousCommand, previousCandidates);
+        return parseSpecial(code[2], command, previousCommand, previousCandidates, plaformData);
 
     case 'answer': {
         const value = ThingTalk.NNSyntax.fromNN(code.slice(1), entities);
-        return new Intent.Answer(ValueCategory.fromValue(value), value);
+        return new Intent.Answer(ValueCategory.fromValue(value), value, plaformData);
     }
     case 'filter': {
         const predicate = ThingTalk.NNSyntax.fromNN(code.slice(1), entities);
-        return new Intent.Predicate(predicate);
+        return new Intent.Predicate(predicate, plaformData);
     }
     case 'category':
-        return new Intent.CommandList(null, code[2]);
+        return new Intent.CommandList(null, code[2], plaformData);
     case 'commands':
-        return new Intent.CommandList(code[3].substring('device:'.length), code[2]);
+        return new Intent.CommandList(code[3].substring('device:'.length), code[2], plaformData);
 
     case 'choice':
-        return new Intent.Answer(ValueCategory.MultipleChoice, parseInt(code[2]));
+        return new Intent.Answer(ValueCategory.MultipleChoice, parseInt(code[2]), plaformData);
 
     default:
         throw new Error('Unrecognized bookkeeping command ' + code[1]);
     }
 }
 
-Intent.parse = function parse(json, schemaRetriever, command, previousCommand, previousCandidates) {
+Intent.parse = function parse(json, schemaRetriever, command, previousCommand, previousCandidates, plaformData) {
     if ('program' in json)
-        return this.parseProgram(json.program, schemaRetriever);
+        return this.parseProgram(json.program, schemaRetriever, plaformData);
 
     let { code, entities } = json;
     for (let name in entities) {
@@ -235,7 +239,7 @@ Intent.parse = function parse(json, schemaRetriever, command, previousCommand, p
     }
 
     if (code[0] === 'bookkeeping')
-        return Promise.resolve(parseBookeeping(code, schemaRetriever, entities, command, previousCommand, previousCandidates));
+        return Promise.resolve(parseBookeeping(code, schemaRetriever, entities, command, previousCommand, previousCandidates, plaformData));
 
     return Promise.resolve().then(() => {
         let program = ThingTalk.NNSyntax.fromNN(code, entities);
@@ -243,24 +247,24 @@ Intent.parse = function parse(json, schemaRetriever, command, previousCommand, p
     }).then((program) => {
         if (program.isProgram) {
             if (program.principal !== null)
-                return new Intent.Setup(program);
+                return new Intent.Setup(program, plaformData);
             else
-                return new Intent.Program(program);
+                return new Intent.Program(program, plaformData);
         } else {
-            return new Intent.PermissionRule(program);
+            return new Intent.PermissionRule(program, plaformData);
         }
     });
 };
 
-Intent.parseProgram = function parseProgram(thingtalk, schemaRetriever) {
+Intent.parseProgram = function parseProgram(thingtalk, schemaRetriever, plaformData) {
     return ThingTalk.Grammar.parseAndTypecheck(thingtalk, schemaRetriever, true).then((prog) => {
         if (prog.isProgram) {
             if (prog.principal !== null)
-                return new Intent.Setup(prog);
+                return new Intent.Setup(prog, plaformData);
             else
-                return new Intent.Program(prog);
+                return new Intent.Program(prog, plaformData);
         } else {
-            return new Intent.PermissionRule(prog);
+            return new Intent.PermissionRule(prog, plaformData);
         }
     });
 };

--- a/lib/semantic.js
+++ b/lib/semantic.js
@@ -109,47 +109,47 @@ ValueCategory.toAskSpecial = function toAskSpecial(expected) {
 
 const Intent = adt.data({
     // internally generated intents
-    Failed: { command: adt.only(Object, null), plaformData: adt.any },
-    Train: { command: adt.only(Object, null), fallbacks: adt.only(Array, null), plaformData: adt.any },
-    Back: { plaformData: adt.any },
-    More: { plaformData: adt.any },
-    Empty: { plaformData: adt.any },
-    Debug: { plaformData: adt.any },
-    Maybe: { plaformData: adt.any },
-    Unsupported: { plaformData: adt.any },
-    Example: { utterance: adt.only(String), targetCode: adt.only(String), plaformData: adt.any },
-    CommandList: { device: adt.only(String, null), category: adt.only(String), plaformData: adt.any },
+    Failed: { command: adt.only(Object, null), platformData: adt.any },
+    Train: { command: adt.only(Object, null), fallbacks: adt.only(Array, null), platformData: adt.any },
+    Back: { platformData: adt.any },
+    More: { platformData: adt.any },
+    Empty: { platformData: adt.any },
+    Debug: { platformData: adt.any },
+    Maybe: { platformData: adt.any },
+    Unsupported: { platformData: adt.any },
+    Example: { utterance: adt.only(String), targetCode: adt.only(String), platformData: adt.any },
+    CommandList: { device: adt.only(String, null), category: adt.only(String), platformData: adt.any },
 
     // special entries in the grammar
-    NeverMind: { plaformData: adt.any }, // cancel the current task
-    Help: { plaformData: adt.any }, // ask for contextual help, or start a new task
-    Make: { plaformData: adt.any }, // reset and start a new task
-    WakeUp: { plaformData: adt.any }, // do nothing and wake up the screen
+    NeverMind: { platformData: adt.any }, // cancel the current task
+    Help: { platformData: adt.any }, // ask for contextual help, or start a new task
+    Make: { platformData: adt.any }, // reset and start a new task
+    WakeUp: { platformData: adt.any }, // do nothing and wake up the screen
 
     // easter eggs
-    Hello: { plaformData: adt.any },
-    Cool: { plaformData: adt.any },
-    ThankYou: { plaformData: adt.any },
-    Sorry: { plaformData: adt.any },
+    Hello: { platformData: adt.any },
+    Cool: { platformData: adt.any },
+    ThankYou: { platformData: adt.any },
+    Sorry: { platformData: adt.any },
 
-    Answer: { category: adt.only(ValueCategory), value: adt.only(Ast.Value, Number), plaformData: adt.any },
+    Answer: { category: adt.only(ValueCategory), value: adt.only(Ast.Value, Number), platformData: adt.any },
 
     // thingtalk
     Program: {
         program: adt.only(Ast.Program),
-        plaformData: adt.any
+        platformData: adt.any
     },
     Predicate: {
         predicate: adt.only(Ast.BooleanExpression),
-        plaformData: adt.any
+        platformData: adt.any
     },
     Setup: {
         program: adt.only(Ast.Program),
-        plaformData: adt.any
+        platformData: adt.any
     },
     PermissionRule: {
         rule: adt.only(Ast.PermissionRule),
-        plaformData: adt.any
+        platformData: adt.any
     }
 });
 
@@ -170,63 +170,63 @@ const SPECIAL_INTENT_MAP = {
     wakeup: Intent.WakeUp,
 };
 
-function parseSpecial(special, command, previousCommand, previousCandidates, plaformData) {
+function parseSpecial(special, command, previousCommand, previousCandidates, platformData) {
     let intent;
     special = special.substring('special:'.length);
     switch (special) {
     case 'yes':
-        intent = new Intent.Answer(ValueCategory.YesNo, Ast.Value.Boolean(true), plaformData);
+        intent = new Intent.Answer(ValueCategory.YesNo, Ast.Value.Boolean(true), platformData);
         intent.isYes = true;
         intent.isNo = false;
         break;
     case 'no':
-        intent = new Intent.Answer(ValueCategory.YesNo, Ast.Value.Boolean(false), plaformData);
+        intent = new Intent.Answer(ValueCategory.YesNo, Ast.Value.Boolean(false), platformData);
         intent.isYes = false;
         intent.isNo = true;
         break;
     case 'failed':
-        intent = new Intent.Failed(command, plaformData);
+        intent = new Intent.Failed(command, platformData);
         break;
     case 'train':
-        intent = new Intent.Train(previousCommand, previousCandidates, plaformData);
+        intent = new Intent.Train(previousCommand, previousCandidates, platformData);
         break;
     default:
         if (!SPECIAL_INTENT_MAP[special])
             throw new Error('Unrecognized special ' + special);
-        intent = new (SPECIAL_INTENT_MAP[special])(plaformData);
+        intent = new (SPECIAL_INTENT_MAP[special])(platformData);
     }
     return intent;
 }
 
-function parseBookeeping(code, schemaRetriever, entities, command, previousCommand, previousCandidates, plaformData) {
+function parseBookeeping(code, schemaRetriever, entities, command, previousCommand, previousCandidates, platformData) {
     switch (code[1]) {
     case 'special':
-        return parseSpecial(code[2], command, previousCommand, previousCandidates, plaformData);
+        return parseSpecial(code[2], command, previousCommand, previousCandidates, platformData);
 
     case 'answer': {
         const value = ThingTalk.NNSyntax.fromNN(code.slice(1), entities);
-        return new Intent.Answer(ValueCategory.fromValue(value), value, plaformData);
+        return new Intent.Answer(ValueCategory.fromValue(value), value, platformData);
     }
     case 'filter': {
         const predicate = ThingTalk.NNSyntax.fromNN(code.slice(1), entities);
-        return new Intent.Predicate(predicate, plaformData);
+        return new Intent.Predicate(predicate, platformData);
     }
     case 'category':
-        return new Intent.CommandList(null, code[2], plaformData);
+        return new Intent.CommandList(null, code[2], platformData);
     case 'commands':
-        return new Intent.CommandList(code[3].substring('device:'.length), code[2], plaformData);
+        return new Intent.CommandList(code[3].substring('device:'.length), code[2], platformData);
 
     case 'choice':
-        return new Intent.Answer(ValueCategory.MultipleChoice, parseInt(code[2]), plaformData);
+        return new Intent.Answer(ValueCategory.MultipleChoice, parseInt(code[2]), platformData);
 
     default:
         throw new Error('Unrecognized bookkeeping command ' + code[1]);
     }
 }
 
-Intent.parse = function parse(json, schemaRetriever, command, previousCommand, previousCandidates, plaformData) {
+Intent.parse = function parse(json, schemaRetriever, command, previousCommand, previousCandidates, platformData) {
     if ('program' in json)
-        return this.parseProgram(json.program, schemaRetriever, plaformData);
+        return this.parseProgram(json.program, schemaRetriever, platformData);
 
     let { code, entities } = json;
     for (let name in entities) {
@@ -239,7 +239,7 @@ Intent.parse = function parse(json, schemaRetriever, command, previousCommand, p
     }
 
     if (code[0] === 'bookkeeping')
-        return Promise.resolve(parseBookeeping(code, schemaRetriever, entities, command, previousCommand, previousCandidates, plaformData));
+        return Promise.resolve(parseBookeeping(code, schemaRetriever, entities, command, previousCommand, previousCandidates, platformData));
 
     return Promise.resolve().then(() => {
         let program = ThingTalk.NNSyntax.fromNN(code, entities);
@@ -247,24 +247,24 @@ Intent.parse = function parse(json, schemaRetriever, command, previousCommand, p
     }).then((program) => {
         if (program.isProgram) {
             if (program.principal !== null)
-                return new Intent.Setup(program, plaformData);
+                return new Intent.Setup(program, platformData);
             else
-                return new Intent.Program(program, plaformData);
+                return new Intent.Program(program, platformData);
         } else {
-            return new Intent.PermissionRule(program, plaformData);
+            return new Intent.PermissionRule(program, platformData);
         }
     });
 };
 
-Intent.parseProgram = function parseProgram(thingtalk, schemaRetriever, plaformData) {
+Intent.parseProgram = function parseProgram(thingtalk, schemaRetriever, platformData) {
     return ThingTalk.Grammar.parseAndTypecheck(thingtalk, schemaRetriever, true).then((prog) => {
         if (prog.isProgram) {
             if (prog.principal !== null)
-                return new Intent.Setup(prog, plaformData);
+                return new Intent.Setup(prog, platformData);
             else
-                return new Intent.Program(prog, plaformData);
+                return new Intent.Program(prog, platformData);
         } else {
-            return new Intent.PermissionRule(prog, plaformData);
+            return new Intent.PermissionRule(prog, platformData);
         }
     });
 };

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -2436,6 +2436,226 @@ null],
 `,
 null],
 
+
+    [
+    (almond) => {
+        return almond.handleThingTalk(`executor = "ABCDEFG"^^tt:username : now => @com.gmail.inbox() => return;`, {
+            contacts: [
+            { value: 'ABCDEFG', principal: 'mock-account:123456789', display: "@slack_user_name" }
+            ]
+        });
+    },
+    `>> Ok, so you want me to tell @slack_user_name: get the emails in your GMail inbox and then send it to me. Is that right?
+>> ask special yesno
+`,
+    ['bookkeeping', 'special', 'special:yes'],
+`>> Consider it done.
+>> ask special null
+`,
+    `{
+  class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
+    monitorable list query receive(in req __principal: Entity(tt:contact),
+                                   in req __program_id: Entity(tt:program_id),
+                                   in req __flow: Number,
+                                   out __kindChannel: Entity(tt:function),
+                                   out sender_name: String,
+                                   out sender_address: Entity(tt:email_address),
+                                   out subject: String,
+                                   out date: Date,
+                                   out labels: Array(String),
+                                   out snippet: String,
+                                   out thread_id: Entity(com.gmail:thread_id),
+                                   out email_id: Entity(com.gmail:email_id));
+  }
+  monitor (@__dyn_0.receive(__principal="mock-account:123456789"^^tt:contact("@slack_user_name"), __program_id=$event.program_id, __flow=0)) => notify;
+}
+remote mock-account:123456789/phone:+15555555555 : uuid-XXXXXX : {
+  class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
+    action send(in req __principal: Entity(tt:contact),
+                in req __program_id: Entity(tt:program_id),
+                in req __flow: Number,
+                in req __kindChannel: Entity(tt:function),
+                in req sender_name: String,
+                in req sender_address: Entity(tt:email_address),
+                in req subject: String,
+                in req date: Date,
+                in req labels: Array(String),
+                in req snippet: String,
+                in req thread_id: Entity(com.gmail:thread_id),
+                in req email_id: Entity(com.gmail:email_id));
+  }
+  now => @com.gmail.inbox() => @__dyn_0.send(__principal="mock-account:123456-SELF"^^tt:contact("me"), __program_id=$event.program_id, __flow=0, __kindChannel=$event.type, sender_name=sender_name, sender_address=sender_address, subject=subject, date=date, labels=labels, snippet=snippet, thread_id=thread_id, email_id=email_id);
+}`],
+
+    [
+    (almond) => {
+        return almond.handleThingTalk(`executor = "ABCDEFG"^^tt:username : now => @com.gmail.inbox() => return;`, {
+            contacts: [
+            { value: 'ABCDEFG', principal: 'email:dummy@example.com', display: "@slack_user_name" }
+            ]
+        });
+    },
+    `>> Ok, so you want me to tell @slack_user_name: get the emails in your GMail inbox and then send it to me. Is that right?
+>> ask special yesno
+`,
+    ['bookkeeping', 'special', 'special:yes'],
+`>> Consider it done.
+>> ask special null
+`,
+    `{
+  class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
+    monitorable list query receive(in req __principal: Entity(tt:contact),
+                                   in req __program_id: Entity(tt:program_id),
+                                   in req __flow: Number,
+                                   out __kindChannel: Entity(tt:function),
+                                   out sender_name: String,
+                                   out sender_address: Entity(tt:email_address),
+                                   out subject: String,
+                                   out date: Date,
+                                   out labels: Array(String),
+                                   out snippet: String,
+                                   out thread_id: Entity(com.gmail:thread_id),
+                                   out email_id: Entity(com.gmail:email_id));
+  }
+  monitor (@__dyn_0.receive(__principal="mock-account:MOCK1234-email:dummy@example.com"^^tt:contact("@slack_user_name"), __program_id=$event.program_id, __flow=0)) => notify;
+}
+remote mock-account:MOCK1234-email:dummy@example.com/phone:+15555555555 : uuid-XXXXXX : {
+  class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
+    action send(in req __principal: Entity(tt:contact),
+                in req __program_id: Entity(tt:program_id),
+                in req __flow: Number,
+                in req __kindChannel: Entity(tt:function),
+                in req sender_name: String,
+                in req sender_address: Entity(tt:email_address),
+                in req subject: String,
+                in req date: Date,
+                in req labels: Array(String),
+                in req snippet: String,
+                in req thread_id: Entity(com.gmail:thread_id),
+                in req email_id: Entity(com.gmail:email_id));
+  }
+  now => @com.gmail.inbox() => @__dyn_0.send(__principal="mock-account:123456-SELF"^^tt:contact("me"), __program_id=$event.program_id, __flow=0, __kindChannel=$event.type, sender_name=sender_name, sender_address=sender_address, subject=subject, date=date, labels=labels, snippet=snippet, thread_id=thread_id, email_id=email_id);
+}`],
+
+    [
+    (almond) => {
+        return almond.handleThingTalk(`executor = "ABCDEFG"^^tt:username : now => @com.gmail.inbox() => return;`, {
+            contacts: [
+            { value: 'GFEDCBA', principal: 'mock-account:123456789', display: "@slack_user_name" }
+            ]
+        });
+    },
+    `>> Multiple contacts match “ABCDEFG”. Who do you mean?
+>> choice 0: Alice Smith (mom)
+>> choice 1: Bob Smith (dad)
+>> ask special choice
+`,
+    ['bookkeeping', 'special', 'special:nevermind'],
+`>> Sorry I couldn't help on that.
+>> ask special null
+`,
+    null],
+
+    [
+    (almond) => {
+        return almond.handleThingTalk(`executor = "mock-account:123456789"^^tt:contact : now => @com.gmail.inbox() => return;`, {
+            contacts: [
+            { value: 'ABCDEFG', principal: 'mock-account:123456789', display: "@slack_user_name" }
+            ]
+        });
+    },
+    `>> Ok, so you want me to tell @slack_user_name: get the emails in your GMail inbox and then send it to me. Is that right?
+>> ask special yesno
+`,
+    ['bookkeeping', 'special', 'special:yes'],
+`>> Consider it done.
+>> ask special null
+`,
+    `{
+  class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
+    monitorable list query receive(in req __principal: Entity(tt:contact),
+                                   in req __program_id: Entity(tt:program_id),
+                                   in req __flow: Number,
+                                   out __kindChannel: Entity(tt:function),
+                                   out sender_name: String,
+                                   out sender_address: Entity(tt:email_address),
+                                   out subject: String,
+                                   out date: Date,
+                                   out labels: Array(String),
+                                   out snippet: String,
+                                   out thread_id: Entity(com.gmail:thread_id),
+                                   out email_id: Entity(com.gmail:email_id));
+  }
+  monitor (@__dyn_0.receive(__principal="mock-account:123456789"^^tt:contact("@slack_user_name"), __program_id=$event.program_id, __flow=0)) => notify;
+}
+remote mock-account:123456789/phone:+15555555555 : uuid-XXXXXX : {
+  class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
+    action send(in req __principal: Entity(tt:contact),
+                in req __program_id: Entity(tt:program_id),
+                in req __flow: Number,
+                in req __kindChannel: Entity(tt:function),
+                in req sender_name: String,
+                in req sender_address: Entity(tt:email_address),
+                in req subject: String,
+                in req date: Date,
+                in req labels: Array(String),
+                in req snippet: String,
+                in req thread_id: Entity(com.gmail:thread_id),
+                in req email_id: Entity(com.gmail:email_id));
+  }
+  now => @com.gmail.inbox() => @__dyn_0.send(__principal="mock-account:123456-SELF"^^tt:contact("me"), __program_id=$event.program_id, __flow=0, __kindChannel=$event.type, sender_name=sender_name, sender_address=sender_address, subject=subject, date=date, labels=labels, snippet=snippet, thread_id=thread_id, email_id=email_id);
+}`],
+
+    [
+    (almond) => {
+        return almond.handleThingTalk(`executor = "mock-account:123456789"^^tt:contact : now => @com.gmail.inbox() => return;`, {
+            contacts: [
+            { value: 'ABCDEFG', principal: 'mock-account:987654321', display: "@slack_user_name" }
+            ]
+        });
+    },
+    `>> Ok, so you want me to tell Some Guy: get the emails in your GMail inbox and then send it to me. Is that right?
+>> ask special yesno
+`,
+    ['bookkeeping', 'special', 'special:yes'],
+`>> Consider it done.
+>> ask special null
+`,
+    `{
+  class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
+    monitorable list query receive(in req __principal: Entity(tt:contact),
+                                   in req __program_id: Entity(tt:program_id),
+                                   in req __flow: Number,
+                                   out __kindChannel: Entity(tt:function),
+                                   out sender_name: String,
+                                   out sender_address: Entity(tt:email_address),
+                                   out subject: String,
+                                   out date: Date,
+                                   out labels: Array(String),
+                                   out snippet: String,
+                                   out thread_id: Entity(com.gmail:thread_id),
+                                   out email_id: Entity(com.gmail:email_id));
+  }
+  monitor (@__dyn_0.receive(__principal="mock-account:123456789"^^tt:contact("Some Guy"), __program_id=$event.program_id, __flow=0)) => notify;
+}
+remote mock-account:123456789/phone:+15555555555 : uuid-XXXXXX : {
+  class @__dyn_0 extends @org.thingpedia.builtin.thingengine.remote {
+    action send(in req __principal: Entity(tt:contact),
+                in req __program_id: Entity(tt:program_id),
+                in req __flow: Number,
+                in req __kindChannel: Entity(tt:function),
+                in req sender_name: String,
+                in req sender_address: Entity(tt:email_address),
+                in req subject: String,
+                in req date: Date,
+                in req labels: Array(String),
+                in req snippet: String,
+                in req thread_id: Entity(com.gmail:thread_id),
+                in req email_id: Entity(com.gmail:email_id));
+  }
+  now => @com.gmail.inbox() => @__dyn_0.send(__principal="mock-account:123456-SELF"^^tt:contact("me"), __program_id=$event.program_id, __flow=0, __kindChannel=$event.type, sender_name=sender_name, sender_address=sender_address, subject=subject, date=date, labels=labels, snippet=snippet, thread_id=thread_id, email_id=email_id);
+}`],
+
     [(almond) => {
     almond._engine.permissions = null;
     almond._engine.remote = null;
@@ -2708,7 +2928,7 @@ null],
 `,
     `{
   now => @com.twitter(id="twitter-bar").post(status="!! test command always nothing !!");
-}`]
+}`],
 ];
 
 function handleCommand(almond, input) {

--- a/test/mock.js
+++ b/test/mock.js
@@ -362,6 +362,10 @@ class MockMessagingManager {
         this.type = 'mock';
         this.account = 'mock-account:123456-SELF';
     }
+
+    getSelf() {
+        return this.account;
+    }
     
     isSelf(principal) {
         return principal === this.account;

--- a/test/mock.js
+++ b/test/mock.js
@@ -356,11 +356,15 @@ class MockAddressBook {
     }
 }
 
-class MockMessaging {
+class MockMessagingManager {
     constructor() {
         this.isAvailable = true;
         this.type = 'mock';
-        this.account = '123456-SELF';
+        this.account = 'mock-account:123456-SELF';
+    }
+    
+    isSelf(principal) {
+        return principal === this.account;
     }
 
     getIdentities() {
@@ -368,7 +372,7 @@ class MockMessaging {
     }
 
     getUserByAccount(account) {
-        if (account === '123456789')
+        if (account === 'mock-account:123456789')
             return Promise.resolve({ name: "Some Guy" });
         else
             return Promise.resolve(null);
@@ -377,7 +381,7 @@ class MockMessaging {
     getAccountForIdentity(identity) {
         if (identity === 'phone:+XXXXXXXXX')
             return Promise.resolve(null);
-        return Promise.resolve('MOCK1234-' + identity);
+        return Promise.resolve('mock-account:MOCK1234-' + identity);
     }
 }
 
@@ -468,7 +472,7 @@ module.exports.createMockEngine = function(thingpediaUrl) {
         devices: new MockDeviceDatabase(),
         apps: new MockAppDatabase(schemas),
         discovery: new MockDiscoveryClient(),
-        messaging: new MockMessaging(),
+        messaging: new MockMessagingManager(),
         remote: new MockRemote(schemas),
         permissions: new MockPermissionManager(schemas)
     };

--- a/test/test_almond.js
+++ b/test/test_almond.js
@@ -96,7 +96,7 @@ function main() {
             if (command === null)
                 return almond.handleParsedCommand(analysis);
             else
-                return almond.handleCommand(command, postprocess);
+                return almond.handleCommand(command, undefined, postprocess);
         }).then(() => {
             rl.prompt();
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -9,12 +9,12 @@
   dependencies:
     "@babel/highlight" "^7.0.0"
 
-"@babel/generator@^7.0.0", "@babel/generator@^7.1.6":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.2.0.tgz#eaf3821fa0301d9d4aef88e63d4bcc19b73ba16c"
-  integrity sha512-BA75MVfRlFQG2EZgFYIwyT1r6xSkwfP2bdkY/kLZusEYWiJs4xCowab/alaEaT0wSvmVuXGqiefeBlP+7V1yKg==
+"@babel/generator@^7.0.0", "@babel/generator@^7.2.2":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.3.0.tgz#f663838cd7b542366de3aa608a657b8ccb2a99eb"
+  integrity sha512-dZTwMvTgWfhmibq4V9X+LMf6Bgl7zAodRn9PvcPdhlzFMbvUutx74dbEv7Atz3ToeEpevYEJtAwfxq/bDCzHWg==
   dependencies:
-    "@babel/types" "^7.2.0"
+    "@babel/types" "^7.3.0"
     jsesc "^2.5.1"
     lodash "^4.17.10"
     source-map "^0.5.0"
@@ -52,39 +52,39 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.0.0", "@babel/parser@^7.1.2", "@babel/parser@^7.1.6":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.2.0.tgz#02d01dbc330b6cbf36b76ac93c50752c69027065"
-  integrity sha512-M74+GvK4hn1eejD9lZ7967qAwvqTZayQa3g10ag4s9uewgR7TKjeaT0YMyoq+gVfKYABiWZ4MQD701/t5e1Jhg==
+"@babel/parser@^7.0.0", "@babel/parser@^7.2.2", "@babel/parser@^7.2.3":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.3.1.tgz#8f4ffd45f779e6132780835ffa7a215fa0b2d181"
+  integrity sha512-ATz6yX/L8LEnC3dtLQnIx4ydcPxhLcoy9Vl6re00zb2w5lG6itY6Vhnr1KFRPq/FHNsgl/gh2mjNN20f9iJTTA==
 
 "@babel/template@^7.0.0", "@babel/template@^7.1.0":
-  version "7.1.2"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.1.2.tgz#090484a574fef5a2d2d7726a674eceda5c5b5644"
-  integrity sha512-SY1MmplssORfFiLDcOETrW7fCLl+PavlwMh92rrGcikQaRq4iWPVH0MpwPpY3etVMx6RnDjXtr6VZYr/IbP/Ag==
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.2.2.tgz#005b3fdf0ed96e88041330379e0da9a708eb2907"
+  integrity sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.1.2"
-    "@babel/types" "^7.1.2"
+    "@babel/parser" "^7.2.2"
+    "@babel/types" "^7.2.2"
 
 "@babel/traverse@^7.0.0":
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.1.6.tgz#c8db9963ab4ce5b894222435482bd8ea854b7b5c"
-  integrity sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==
+  version "7.2.3"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.2.3.tgz#7ff50cefa9c7c0bd2d81231fdac122f3957748d8"
+  integrity sha512-Z31oUD/fJvEWVR0lNZtfgvVt512ForCTNKYcJBGbPb1QZfve4WGH8Wsy7+Mev33/45fhP/hwQtvgusNdcCMgSw==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@babel/generator" "^7.1.6"
+    "@babel/generator" "^7.2.2"
     "@babel/helper-function-name" "^7.1.0"
     "@babel/helper-split-export-declaration" "^7.0.0"
-    "@babel/parser" "^7.1.6"
-    "@babel/types" "^7.1.6"
+    "@babel/parser" "^7.2.3"
+    "@babel/types" "^7.2.2"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.10"
 
-"@babel/types@^7.0.0", "@babel/types@^7.1.2", "@babel/types@^7.1.6", "@babel/types@^7.2.0":
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.2.0.tgz#7941c5b2d8060e06f9601d6be7c223eef906d5d8"
-  integrity sha512-b4v7dyfApuKDvmPb+O488UlGuR1WbwMXFsO/cyqMrnfvRAChZKJAYeeglWTjUO1b9UghKKgepAQM5tsvBJca6A==
+"@babel/types@^7.0.0", "@babel/types@^7.2.2", "@babel/types@^7.3.0":
+  version "7.3.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.3.0.tgz#61dc0b336a93badc02bf5f69c4cd8e1353f2ffc0"
+  integrity sha512-QkFPw68QqWU1/RVPyBe8SO7lXbPfjtqAxRYQKpFpaB8yMq7X2qAqfwK5LKoQufEkSmO5NQ70O6Kc3Afk03RwXw==
   dependencies:
     esutils "^2.0.2"
     lodash "^4.17.10"
@@ -96,9 +96,9 @@ acorn-jsx@^5.0.0:
   integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
 
 acorn@^6.0.2:
-  version "6.0.4"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.4.tgz#77377e7353b72ec5104550aa2d2097a2fd40b754"
-  integrity sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==
+  version "6.0.6"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.0.6.tgz#cd75181670d5b99bdb1b1c993941d3a239ab1f56"
+  integrity sha512-5M3G/A4uBSMIlfJ+h9W125vJvPFH/zirISsW5qfxF5YzEvXJCtolLoQvM5yZft0DvMcUrPGKPOlgEu55I6iUtA==
 
 addressparser@^1.0.1:
   version "1.0.1"
@@ -111,19 +111,19 @@ adt@~0.7.2:
   integrity sha1-gku3Jf42MsjDXsJJhd9hD5fZgkQ=
 
 ajv@^6.5.3, ajv@^6.5.5, ajv@^6.6.1:
-  version "6.6.1"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.6.1.tgz#6360f5ed0d80f232cc2b294c362d5dc2e538dd61"
-  integrity sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.7.0.tgz#e3ce7bb372d6577bb1839f1dfdfcbf5ad2948d96"
+  integrity sha512-RZXPviBTtfmtka9n9sy1N5M5b82CbxWIR6HIis4s3WQTXDJamc/0gpCWNGz6EWdWp4DOfjzJfhz/AS9zVPjjWg==
   dependencies:
     fast-deep-equal "^2.0.1"
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-escapes@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.1.0.tgz#f73207bb81207d75fd6c83f125af26eea378ca30"
-  integrity sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==
+ansi-escapes@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
+  integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-regex@^2.0.0:
   version "2.1.1"
@@ -255,17 +255,10 @@ caching-transform@^2.0.0:
     package-hash "^2.0.0"
     write-file-atomic "^2.0.0"
 
-caller-path@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/caller-path/-/caller-path-0.1.0.tgz#94085ef63581ecd3daa92444a8fe94e82577751f"
-  integrity sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=
-  dependencies:
-    callsites "^0.2.0"
-
-callsites@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/callsites/-/callsites-0.2.0.tgz#afab96262910a7f33c19a5775825c69f34e350ca"
-  integrity sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=
+callsites@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.0.0.tgz#fb7eb569b72ad7a45812f93fd9430a3e410b3dd3"
+  integrity sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==
 
 camelcase@^4.1.0:
   version "4.1.0"
@@ -277,10 +270,10 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-chalk@^2.0.0, chalk@^2.1.0:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.1.tgz#18c49ab16a037b6eb0152cc83e3471338215b66e"
-  integrity sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
+  integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
   dependencies:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
@@ -433,9 +426,9 @@ debug@^3.1.0:
     ms "^2.1.1"
 
 debug@^4.0.1, debug@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
-  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -512,9 +505,9 @@ eslint-visitor-keys@^1.0.0:
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
 eslint@^5.3.0:
-  version "5.10.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.10.0.tgz#24adcbe92bf5eb1fc2d2f2b1eebe0c5e0713903a"
-  integrity sha512-HpqzC+BHULKlnPwWae9MaVZ5AXJKpkxCVXQHrFaRw3hbDj26V/9ArYM4Rr/SQ8pi6qUPLXSSXC4RBJlyq2Z2OQ==
+  version "5.13.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.13.0.tgz#ce71cc529c450eed9504530939aa97527861ede9"
+  integrity sha512-nqD5WQMisciZC5EHZowejLKQjWGuFS5c70fxqSKlnDME+oz9zmE8KTlX+lHSg+/5wsC/kf9Q9eMkC8qS3oM2fg==
   dependencies:
     "@babel/code-frame" "^7.0.0"
     ajv "^6.5.3"
@@ -533,6 +526,7 @@ eslint@^5.3.0:
     glob "^7.1.2"
     globals "^11.7.0"
     ignore "^4.0.6"
+    import-fresh "^3.0.0"
     imurmurhash "^0.1.4"
     inquirer "^6.1.0"
     js-yaml "^3.12.0"
@@ -544,10 +538,8 @@ eslint@^5.3.0:
     natural-compare "^1.4.0"
     optionator "^0.8.2"
     path-is-inside "^1.0.2"
-    pluralize "^7.0.0"
     progress "^2.0.0"
     regexpp "^2.0.1"
-    require-uncached "^1.0.3"
     semver "^5.5.1"
     strip-ansi "^4.0.0"
     strip-json-comments "^2.0.1"
@@ -610,7 +602,7 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^3.0.0:
+external-editor@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.0.3.tgz#5866db29a97826dbe4bf3afd24070ead9ea43a27"
   integrity sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==
@@ -756,7 +748,7 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@^7.0.5, glob@^7.1.2, glob@^7.1.3:
+glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -769,9 +761,9 @@ glob@^7.0.5, glob@^7.1.2, glob@^7.1.3:
     path-is-absolute "^1.0.0"
 
 globals@^11.1.0, globals@^11.7.0:
-  version "11.9.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.9.0.tgz#bde236808e987f290768a93d065060d78e6ab249"
-  integrity sha512-5cJVtyXWH8PiJPVLZzzoIizXx944O4OmRro5MWKx5fT4MgcN7OfaMutPeaTdJCCURwbWdhhcCWcKIffPnmTzBg==
+  version "11.10.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-11.10.0.tgz#1e09776dffda5e01816b3bb4077c8b59c24eaa50"
+  integrity sha512-0GZF1RiPKU97IHUO5TORo9w1PwrH/NBPl+fS7oMLdaTRiYmYbwK4NWoZWrAdd0/abG9R2BU+OiwyQpTpE6pdfQ==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2:
   version "4.1.15"
@@ -838,6 +830,14 @@ ignore@^4.0.6:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
+import-fresh@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.0.0.tgz#a3d897f420cab0e671236897f75bc14b4885c390"
+  integrity sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
 imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
@@ -857,20 +857,20 @@ inherits@2, inherits@~2.0.3:
   integrity sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=
 
 inquirer@^6.1.0:
-  version "6.2.1"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.1.tgz#9943fc4882161bdb0b0c9276769c75b32dbfcd52"
-  integrity sha512-088kl3DRT2dLU5riVMKKr1DlImd6X7smDhpXUCkJDCKvTEJeRiXh0G132HG9u5a+6Ylw9plFRY7RuTnwohYSpg==
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.2.2.tgz#46941176f65c9eb20804627149b743a218f25406"
+  integrity sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==
   dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
+    ansi-escapes "^3.2.0"
+    chalk "^2.4.2"
     cli-cursor "^2.1.0"
     cli-width "^2.0.0"
-    external-editor "^3.0.0"
+    external-editor "^3.0.3"
     figures "^2.0.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
     mute-stream "0.0.7"
     run-async "^2.2.0"
-    rxjs "^6.1.0"
+    rxjs "^6.4.0"
     string-width "^2.1.0"
     strip-ansi "^5.0.0"
     through "^2.3.6"
@@ -997,9 +997,9 @@ js-tokens@^4.0.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.11.0, js-yaml@^3.12.0:
-  version "3.12.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.0.tgz#eaed656ec8344f10f527c6bfa1b6e2244de167d1"
-  integrity sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==
+  version "3.12.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
+  integrity sha512-um46hB9wNOKlwkHgiuyEVAybXBjwFUV0Z/RaHJblRd9DXltue9FTYvzCr9ErQrK9Adz5MU4gHWVaNUfdmrC8qA==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -1218,9 +1218,9 @@ mkdirp@^0.5.0, mkdirp@^0.5.1:
     minimist "0.0.8"
 
 mri@^1.1.0:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.1.tgz#85aa26d3daeeeedf80dc5984af95cc5ca5cad9f1"
-  integrity sha1-haom09ru7t+A3FmEr5XMXKXK2fE=
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/mri/-/mri-1.1.4.tgz#7cb1dd1b9b40905f1fac053abe25b6720f44744a"
+  integrity sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==
 
 ms@^2.1.1:
   version "2.1.1"
@@ -1250,9 +1250,9 @@ node-gettext@^2.0.0:
     lodash.get "^4.4.2"
 
 normalize-package-data@^2.3.2:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.0.tgz#12f95a307d58352075a04907b84ac8be98ac012f"
-  integrity sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.4.2.tgz#6b2abd85774e51f7936f1395e45acb905dc849b2"
+  integrity sha512-YcMnjqeoUckXTPKZSAsPjUPLxH85XotbpqK3w4RyCwdFQSU5FxxBys8buehkSfg0j9fKvV1hn7O0+8reEgkAiw==
   dependencies:
     hosted-git-info "^2.1.4"
     is-builtin-module "^1.0.0"
@@ -1383,9 +1383,9 @@ p-limit@^1.1.0:
     p-try "^1.0.0"
 
 p-limit@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.0.0.tgz#e624ed54ee8c460a778b3c9f3670496ff8a57aec"
-  integrity sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.1.0.tgz#1d5a0d20fb12707c758a655f6bbc4386b5930d68"
+  integrity sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==
   dependencies:
     p-try "^2.0.0"
 
@@ -1422,6 +1422,13 @@ package-hash@^2.0.0:
     lodash.flattendeep "^4.4.0"
     md5-hex "^2.0.0"
     release-zalgo "^1.0.0"
+
+parent-module@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.0.tgz#df250bdc5391f4a085fb589dad761f5ad6b865b5"
+  integrity sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-json@^4.0.0:
   version "4.0.0"
@@ -1475,11 +1482,6 @@ pkg-dir@^3.0.0:
   dependencies:
     find-up "^3.0.0"
 
-pluralize@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-7.0.0.tgz#298b89df8b93b0221dbf421ad2b1b1ea23fc6777"
-  integrity sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==
-
 prelude-ls@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
@@ -1501,9 +1503,9 @@ pseudomap@^1.0.2:
   integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 psl@^1.1.24:
-  version "1.1.29"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.29.tgz#60f580d360170bb722a797cc704411e6da850c67"
-  integrity sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==
+  version "1.1.31"
+  resolved "https://registry.yarnpkg.com/psl/-/psl-1.1.31.tgz#e9aa86d0101b5b105cbe93ac6b784cd547276184"
+  integrity sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==
 
 punycode@^1.4.1:
   version "1.4.1"
@@ -1598,19 +1600,6 @@ require-main-filename@^1.0.1:
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-1.0.1.tgz#97f717b69d48784f5f526a6c5aa8ffdda055a4d1"
   integrity sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=
 
-require-uncached@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/require-uncached/-/require-uncached-1.0.3.tgz#4e0d56d6c9662fd31e43011c4b95aa49955421d3"
-  integrity sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=
-  dependencies:
-    caller-path "^0.1.0"
-    resolve-from "^1.0.0"
-
-resolve-from@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-1.0.1.tgz#26cbfe935d1aeeeabb29bc3fe5aeb01e93d44226"
-  integrity sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=
-
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
@@ -1625,11 +1614,11 @@ restore-cursor@^2.0.0:
     signal-exit "^3.0.2"
 
 rimraf@^2.6.2, rimraf@~2.6.2:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
-  integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
   dependencies:
-    glob "^7.0.5"
+    glob "^7.1.3"
 
 run-async@^2.2.0:
   version "2.3.0"
@@ -1638,10 +1627,10 @@ run-async@^2.2.0:
   dependencies:
     is-promise "^2.1.0"
 
-rxjs@^6.1.0:
-  version "6.3.3"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.3.3.tgz#3c6a7fa420e844a81390fb1158a9ec614f4bad55"
-  integrity sha512-JTWmoY9tWCs7zvIk/CvRjhjGaOd+OVBM987mxFo+OW66cGpdKjZcpmc74ES1sB//7Kl/PAe8+wEakuhG4pcgOw==
+rxjs@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
+  integrity sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==
   dependencies:
     tslib "^1.9.0"
 
@@ -1687,10 +1676,10 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
   integrity sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=
 
-slice-ansi@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.0.0.tgz#5373bdb8559b45676e8541c66916cdd6251612e7"
-  integrity sha512-4j2WTWjp3GsZ+AOagyzVbzp4vWGtZ0hEZ/gDY/uTvm6MTxUfTUIsnMIFb1bn8o0RuXiqUw15H1bue8f22Vw2oQ==
+slice-ansi@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
   dependencies:
     ansi-styles "^3.2.0"
     astral-regex "^1.0.0"
@@ -1747,9 +1736,9 @@ spdx-expression-parse@^3.0.0:
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.2.tgz#a59efc09784c2a5bada13cfeaf5c75dd214044d2"
-  integrity sha512-qky9CVt0lVIECkEsYbNILVnPvycuEBkXoMFLRWsREkomQLevYhtRKC+R91a5TOAQ3bCMjikRwhyaRqj1VYatYg==
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.3.tgz#81c0ce8f21474756148bbb5f3bfc0f36bf15d76e"
+  integrity sha512-uBIcIl3Ih6Phe3XHK1NqboJLdGfwr1UN3k6wSD1dZpmPsIkb8AGNbZYJ1fOBk834+Gxy8rpfDxrS6XLEMZMY2g==
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -1757,9 +1746,9 @@ sprintf-js@~1.0.2:
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 sshpk@^1.7.0:
-  version "1.15.2"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.15.2.tgz#c946d6bd9b1a39d0e8635763f5242d6ed6dcb629"
-  integrity sha512-Ra/OXQtuh0/enyl4ETZAfTaeksa6BXks5ZcjpSUNrjBr0DvrJKX+1fsKDPpT9TBXgHAFsa4510aNVgI8g/+SzA==
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.16.1.tgz#fb661c0bef29b39db40769ee39fa70093d6f6877"
+  integrity sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
   dependencies:
     asn1 "~0.2.3"
     assert-plus "^1.0.0"
@@ -1839,13 +1828,13 @@ supports-color@^5.3.0, supports-color@^5.4.0:
     has-flag "^3.0.0"
 
 table@^5.0.2:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/table/-/table-5.1.1.tgz#92030192f1b7b51b6eeab23ed416862e47b70837"
-  integrity sha512-NUjapYb/qd4PeFW03HnAuOJ7OMcBkJlqeClWxeNlQ0lXGSb52oZXGzkO0/I0ARegQ2eUT1g2VDJH0eUxDRcHmw==
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.2.2.tgz#61d474c9e4d8f4f7062c98c7504acb3c08aa738f"
+  integrity sha512-f8mJmuu9beQEDkKHLzOv4VxVYlU68NpdzjbGPl69i4Hx0sTopJuNxuzJd17iV2h24dAfa93u794OnDA5jqXvfQ==
   dependencies:
     ajv "^6.6.1"
     lodash "^4.17.11"
-    slice-ansi "2.0.0"
+    slice-ansi "^2.0.0"
     string-width "^2.1.1"
 
 test-exclude@^5.0.0:
@@ -1873,9 +1862,9 @@ thingpedia-client@^0.2.0:
     tmp "0.0.33"
 
 thingpedia@^2.3.0:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/thingpedia/-/thingpedia-2.3.2.tgz#7029a12fee60079622b23ba9d5f82a4ab9605c25"
-  integrity sha512-ldxHUU+Wv3Q0THhxmIWA9DH4aEyfmHjboouTYWfGKaVRAtDJp3KGPCy/71qXVUTaD9QcnHXIKB20tY4wQ7XvSw==
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/thingpedia/-/thingpedia-2.3.3.tgz#075dce993fa34d68699bd6eb525b41d657055d24"
+  integrity sha512-m/ee/iT/1WgnU75eRlUUeR/qT6QFY4XpCxQJuiCdNtGNb9VXdTBsEppcscOnDV3Ou/NQEJwiWLevOhwSZqprAA==
   dependencies:
     feedparser "^2.2.9"
     ip "~1.1.0"
@@ -1886,9 +1875,9 @@ thingpedia@^2.3.0:
     xml2js "^0.4.17"
 
 thingtalk@^1.4.1, thingtalk@~1.4.0, thingtalk@~1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/thingtalk/-/thingtalk-1.4.1.tgz#795a997dcd4d64a6431c1bd771a7c7676455f877"
-  integrity sha512-mrk4l/OHjI3TQeK362/oiikkvsoTBBLNaUxQnY2k8/XhuvaQQ0DTXQRGDOUi+yBE9Oom5RRnPgaghYuRr5UDWA==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/thingtalk/-/thingtalk-1.4.2.tgz#deab7fb65ccc06c53f978c84f2689bfe646edfde"
+  integrity sha512-xtNx8sOdit1oMr5Ej4RxcwAq1fdG/CxRlmh8/WMl9CI1nF9WDFD6/Jg17zkhORp4xoq61mnfOLmdMR4T5rdXAw==
   dependencies:
     adt "~0.7.2"
     byline "^5.0.0"
@@ -2027,9 +2016,9 @@ wrappy@1:
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
 
 write-file-atomic@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.3.0.tgz#1ff61575c2e2a4e8e510d6fa4e243cce183999ab"
-  integrity sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-2.4.2.tgz#a7181706dfba17855d221140a9c06e15fcdd87b9"
+  integrity sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==
   dependencies:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"


### PR DESCRIPTION
Introduce a metadata mechanism by which bridges can inject information about users named in a command, when available through external means.

This is somewhat of a HACK, and maybe a better design would be for the slack bridge to provide an implementation of almond-cloud's platform's contact-api (like almond-server would do in a multi-profile environment with speaker ID). But I don't want to merge the slack bridge in almond-cloud proper, and until thingengine-core grows a multi-device contact manager, this is seems to work.