### PR TITLE
Prepare from removal of statistics module from thingengine-core

### DIFF
--- a/lib/almond.js
+++ b/lib/almond.js
@@ -72,6 +72,11 @@ function apiCompat(user, manager) {
         user.logPermissionRule = async function(uniqueId, policy, description, metadata) {};
 }
 
+const DummyStatistics = {
+    hit() {
+    }
+};
+
 module.exports = class Almond extends events.EventEmitter {
     constructor(engine, conversationId, user, delegate, options) {
         super();
@@ -95,6 +100,10 @@ module.exports = class Almond extends events.EventEmitter {
         this._ = function(string) {
             return gettext.dgettext('almond', string);
         };
+
+        this._stats = this._engine.platform.getCapability('statistics');
+        if (this._stats === null)
+            this._stats = DummyStatistics;
 
         this._raw = false;
         this._options = options || {};
@@ -132,7 +141,7 @@ module.exports = class Almond extends events.EventEmitter {
     }
 
     get stats() {
-        return this._engine.stats;
+        return this._stats;
     }
 
     get apps() {

--- a/lib/dialogs/fallback.js
+++ b/lib/dialogs/fallback.js
@@ -133,7 +133,12 @@ module.exports = async function fallback(dlg, intent) {
         dlg.manager.stats.hit('sabrina-online-learn');
         dlg.manager.parser.onlineLearn(command.utterance, chosen.code);
 
-        let count = dlg.manager.stats.get('sabrina-online-learn');
+        const prefs = dlg.manager.platform.getSharedPreferences();
+        let count = prefs.get('almond-online-learn-count');
+        if (count === undefined)
+            count = 0;
+        count++;
+        prefs.set('almond-online-learn-count', count);
 
         dlg.reply(dlg._("Thanks, I made a note of that."));
         dlg.reply(dlg.ngettext("You have trained me with %d sentence.", "You have trained me with %d sentences.", count).format(count));

--- a/test/mock.js
+++ b/test/mock.js
@@ -36,35 +36,6 @@ class MockPreferences {
     }
 }
 
-class MockStatistics {
-    constructor() {
-        this._store = {};
-    }
-
-    snapshot() {
-        console.log('Statistics snapshot');
-    }
-
-    keys() {
-        return Object.keys(this._store);
-    }
-
-    set(key, value) {
-        return this._store[key] = value;
-    }
-
-    get(key) {
-        return this._store[key];
-    }
-
-    hit(key) {
-        var old = this._store[key];
-        if (old === undefined)
-            old = 0;
-        this._store[key] = old+1;
-    }
-}
-
 class MockAppDatabase {
     constructor(schemas) {
         this._apps = {};
@@ -443,12 +414,14 @@ const _mockPlatform = {
     },
 
     getCapability(cap) {
-        if (cap === 'gettext')
+        switch (cap) {
+        case 'gettext':
             return _gettext;
-        else if (cap === 'contacts')
+        case 'contacts':
             return new MockAddressBook();
-        else
+        default:
             return null;
+        }
     }
 };
 
@@ -462,7 +435,6 @@ module.exports.createMockEngine = function(thingpediaUrl) {
 
     return {
         platform: _mockPlatform,
-        stats: new MockStatistics,
         thingpedia: thingpedia,
         schemas: schemas,
         devices: new MockDeviceDatabase(),


### PR DESCRIPTION
The statistics module in thingengine-core is not well thought-out, has no design on how to actually collect the data, it's on its way out.
Lets minimize our reliance on it.