### PR TITLE
Adapt to changes in ThingTalk

### DIFF
--- a/lib/dialogs/rule.js
+++ b/lib/dialogs/rule.js
@@ -250,7 +250,7 @@ module.exports = async function ruleDialog(dlg, intent, skipConfirmation, unique
 
     await dlg.manager.user.logProgramExecution(uniqueId, program, description, appMeta);
 
-    const code = program.prettyprint();
+    const code = program.prettyprint(false);
     const app = await dlg.manager.apps.loadOneApp(code, appMeta, uniqueId, undefined,
                                                   name, description, true);
 

--- a/lib/dialogs/setup.js
+++ b/lib/dialogs/setup.js
@@ -83,7 +83,7 @@ module.exports = async function setupDialog(dlg, intent) {
     let ownprograms = program.lowerReturn(dlg.manager.messaging);
     if (ownprograms.length > 0) {
         for (let prog of ownprograms) {
-            let code = prog.prettyprint();
+            let code = prog.prettyprint(false);
             await dlg.manager.apps.loadOneApp(code, appMeta, uniqueId, undefined,
                                               name, description, true);
         }

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -112,7 +112,7 @@ function addPermission(perm) {
 
 var remoteApps = '';
 function installProgramRemote(principal, identity, uniqueId, program) {
-    remoteApps += `\nremote ${principal}/${identity} : ${uniqueId} : ${program.prettyprint()}`;
+    remoteApps += `\nremote ${principal}/${identity} : ${uniqueId} : ${program.prettyprint(false)}`;
     return Promise.resolve();
 }
 


### PR DESCRIPTION
The default of prettyprint() changed from short = false to
short = true. This has no functional effect (it only changes the indentation
and wrapping of generated code) but it causes our tests to fail.

Be can be more forward compatible by explicitly passing false.