### PR TITLE
Remove all handling of easter eggs

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -331,15 +331,6 @@ module.exports = class Dispatcher {
         if (command.isWakeUp) // nothing to do
             return true;
 
-        if (command.isHello)
-            return this.reply(this._("Hi!"));
-        if (command.isCool)
-            return this.reply(this._("I know, right?"));
-        if (command.isSorry)
-            return this.reply(this._("No need to be sorry."));
-        if (command.isThankYou)
-            return this.reply(this._("At your service."));
-
         // if we're expecting the user to click on More... or press cancel,
         // three things can happen
         if (this.expecting === ValueCategory.More) {

--- a/lib/reconstruct_canonical.js
+++ b/lib/reconstruct_canonical.js
@@ -26,14 +26,6 @@ module.exports = function reconstructCanonical(dlg, code, entities) {
             return "help";
         if (intent.isMake)
             return "make a command";
-        if (intent.isHello)
-            return "hello";
-        if (intent.isCool)
-            return "this is cool";
-        if (intent.isThankYou)
-            return "thank you";
-        if (intent.isSorry)
-            return "i'm sorry";
         if (intent.isWakeUp)
             return "almond, wake up!";
         if (intent.isAnswer)

--- a/lib/semantic.js
+++ b/lib/semantic.js
@@ -126,12 +126,6 @@ const Intent = adt.data({
     Make: { platformData: adt.any }, // reset and start a new task
     WakeUp: { platformData: adt.any }, // do nothing and wake up the screen
 
-    // easter eggs
-    Hello: { platformData: adt.any },
-    Cool: { platformData: adt.any },
-    ThankYou: { platformData: adt.any },
-    Sorry: { platformData: adt.any },
-
     Answer: { category: adt.only(ValueCategory), value: adt.only(Ast.Value, Number), platformData: adt.any },
 
     // thingtalk
@@ -162,11 +156,6 @@ const SPECIAL_INTENT_MAP = {
     debug: Intent.Debug,
     help: Intent.Help,
     maybe: Intent.Maybe,
-    hello: Intent.Hello,
-    cool: Intent.Cool,
-    thankyou: Intent.ThankYou,
-    thank_you: Intent.ThankYou,
-    sorry: Intent.Sorry,
     wakeup: Intent.WakeUp,
 };
 

--- a/lib/semantic.js
+++ b/lib/semantic.js
@@ -180,9 +180,10 @@ function parseSpecial(special, command, previousCommand, previousCandidates, pla
         intent = new Intent.Train(previousCommand, previousCandidates, platformData);
         break;
     default:
-        if (!SPECIAL_INTENT_MAP[special])
-            throw new Error('Unrecognized special ' + special);
-        intent = new (SPECIAL_INTENT_MAP[special])(platformData);
+        if (SPECIAL_INTENT_MAP[special])
+            intent = new (SPECIAL_INTENT_MAP[special])(platformData);
+        else
+            intent = new Intent.Failed(command, platformData);
     }
     return intent;
 }


### PR DESCRIPTION
They should be builtin Thingpedia functions that return messages,
they don't need special paths in almond-dialog-agent.

Note: after we merge this, and before the release, we should update our datasets to remove these special entries, otherwise they would cause an error, which is not nice.