### PR TITLE
Fix contextual help

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -413,10 +413,12 @@ module.exports = class Dispatcher {
     }
 
     _handleContextualHelp(command) {
-        if (this.expecting !== null)
-            return this.lookingFor();
-        else
+        if (this.expecting !== null) {
+            this.lookingFor();
+            return true;
+        } else {
             return false;
+        }
     }
 
     dispatchAskForPermission(principal, identity, program) {

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -3018,6 +3018,25 @@ remote mock-account:123456789/phone:+15555555555 : uuid-XXXXXX : {
         ['bookkeeping', 'special', 'special:yes'],
         `>> Consider it done.\n>> ask special null\n`,
         `{\n  now => @com.twitter(id="twitter-foo").post(status="hello");\n}`
+    ],
+
+    // contextual help
+    [
+        '\\t now => @org.thingpedia.builtin.thingengine.builtin.get_random_between(high=6) => notify;',
+`>> What should be the lower bound?
+>> ask special number
+`,
+['bookkeeping', 'special', 'special:help'],
+`>> Could you give me a number?
+>> ask special number
+`,
+        ['bookkeeping', 'answer', '0'],
+`>> Sorry, I did not find any result for that.
+>> ask special null
+`,
+        `{
+  now => @org.thingpedia.builtin.thingengine.builtin(id="thingengine-own-global").get_random_between(high=6, low=0) => notify;
+}`
     ]
 ];
 


### PR DESCRIPTION
_handleContextualHelp must return true when the help is to be handled
contextually (instead of changing the subject)

Fixes #75 