### PR TITLE
Add link to register matrix account when there is no messaging account

### DIFF
--- a/lib/dialogs/messaging.js
+++ b/lib/dialogs/messaging.js
@@ -19,7 +19,8 @@ module.exports = {
     ensureMessagingConfigured(dlg) {
         if (!dlg.manager.messaging.isAvailable) {
             dlg.reply(dlg._("You haven't configured a Matrix account yet. You need a Matrix account to let me talk to other Almonds."));
-            return promptConfigure(dlg, 'messaging');
+            dlg.replyLink(dlg._("Register a new Matrix account"), 'https://riot.im/app/#/register');
+            return promptConfigure(dlg, 'org.thingpedia.builtin.matrix');
         } else {
             return Promise.resolve();
         }

--- a/lib/dialogs/messaging.js
+++ b/lib/dialogs/messaging.js
@@ -18,7 +18,7 @@ module.exports = {
 
     ensureMessagingConfigured(dlg) {
         if (!dlg.manager.messaging.isAvailable) {
-            dlg.reply(dlg._("You need a Matrix account: I talk to other Almonds via secure Matrix messaging service."));
+            dlg.reply(dlg._("You need a Matrix account: I talk to other Almonds via the secure Matrix messaging service."));
             dlg.replyLink(dlg._("Register a new Matrix account now"), 'https://riot.im/app/#/register');
             return promptConfigure(dlg, 'org.thingpedia.builtin.matrix');
         } else {

--- a/lib/dialogs/messaging.js
+++ b/lib/dialogs/messaging.js
@@ -18,8 +18,8 @@ module.exports = {
 
     ensureMessagingConfigured(dlg) {
         if (!dlg.manager.messaging.isAvailable) {
-            dlg.reply(dlg._("You haven't configured a Matrix account yet. You need a Matrix account to let me talk to other Almonds."));
-            dlg.replyLink(dlg._("Register a new Matrix account"), 'https://riot.im/app/#/register');
+            dlg.reply(dlg._("You need a Matrix account: I talk to other Almonds via secure Matrix messaging service."));
+            dlg.replyLink(dlg._("Register a new Matrix account now"), 'https://riot.im/app/#/register');
             return promptConfigure(dlg, 'org.thingpedia.builtin.matrix');
         } else {
             return Promise.resolve();

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -652,8 +652,8 @@ const TEST_CASES = [
     [
     { code: ['executor', '=', 'USERNAME_0', ':', 'now', '=>', '@com.twitter.post'],
       entities: { USERNAME_0: 'mom' } },
-`>> You haven't configured a Matrix account yet. You need a Matrix account to let me talk to other Almonds.
->> link: Register a new Matrix account https://riot.im/app/#/register
+`>> You need a Matrix account: I talk to other Almonds via secure Matrix messaging service.
+>> link: Register a new Matrix account now https://riot.im/app/#/register
 >> Insert your Matrix username:
 >> ask special raw_string
 `,

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -653,6 +653,7 @@ const TEST_CASES = [
     { code: ['executor', '=', 'USERNAME_0', ':', 'now', '=>', '@com.twitter.post'],
       entities: { USERNAME_0: 'mom' } },
 `>> You haven't configured a Matrix account yet. You need a Matrix account to let me talk to other Almonds.
+>> link: Register a new Matrix account https://riot.im/app/#/register
 >> Insert your Matrix username:
 >> ask special raw_string
 `,

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -652,7 +652,7 @@ const TEST_CASES = [
     [
     { code: ['executor', '=', 'USERNAME_0', ':', 'now', '=>', '@com.twitter.post'],
       entities: { USERNAME_0: 'mom' } },
-`>> You need a Matrix account: I talk to other Almonds via secure Matrix messaging service.
+`>> You need a Matrix account: I talk to other Almonds via the secure Matrix messaging service.
 >> link: Register a new Matrix account now https://riot.im/app/#/register
 >> Insert your Matrix username:
 >> ask special raw_string


### PR DESCRIPTION
Most users don't have a matrix account, so we should give them a link
to register one.

The link shows up as a button, not an RDL, which seems more appropriate.