### PR TITLE
Slot fill entities by name instead of ID

### DIFF
--- a/lib/dialogs/slot_filling.js
+++ b/lib/dialogs/slot_filling.js
@@ -141,7 +141,11 @@ async function slotFillCustomRaw(dlg, slotType, question) {
         return await dlg.ask(ValueCategory.Picture, question);
     else if (slotType.isEntity && slotType.type === 'tt:contact')
         return await dlg.ask(ValueCategory.PhoneNumber, question);
-    else if (slotType.isString || slotType.isEntity)
+    else if (slotType.isEntity && (slotType.type === 'tt:hashtag' || slotType.type === 'tt:username'))
+        return new Ast.Value.Entity((await dlg.ask(ValueCategory.RawString, question)).value, slotType.type, null);
+    else if (slotType.isEntity)
+        return new Ast.Value.Entity(null, slotType.type, (await dlg.ask(ValueCategory.RawString, question)).value);
+    else if (slotType.isString)
         return await dlg.ask(ValueCategory.RawString, question);
     else if (slotType.isMeasure)
         return await dlg.ask(ValueCategory.Measure(slotType.unit), question);

--- a/test/auto_test_almond.js
+++ b/test/auto_test_almond.js
@@ -3567,7 +3567,35 @@ null],
 `,
     `{
   now => (@com.twitter(id="twitter-foo").search()), hashtags == ["foo"^^tt:hashtag, "bar"^^tt:hashtag] => notify;
-}`]
+}`],
+
+    [
+    ['now', '=>', '@com.cryptonator.get_price', '=>', 'notify'],
+`>> What crypto currency do you want to check?
+>> context = now => @com.cryptonator.get_price => notify // {}
+>> ask special raw_string
+`,
+    `bitcoin`,
+`>> Sorry, I did not find any result for that.
+>> context = now => @com.cryptonator.get_price param:currency:Entity(tt:cryptocurrency_code) = GENERIC_ENTITY_tt:cryptocurrency_code_0 => notify // {"GENERIC_ENTITY_tt:cryptocurrency_code_0":{"value":"btc","display":"Bitcoin"}}
+>> ask special null
+`,
+    `{
+  now => @com.cryptonator(id="com.cryptonator-50").get_price(currency="btc"^^tt:cryptocurrency_code("Bitcoin")) => notify;
+}`],
+
+    [
+    ['now', '=>', '@com.cryptonator.get_price', '=>', 'notify'],
+`>> What crypto currency do you want to check?
+>> context = now => @com.cryptonator.get_price => notify // {}
+>> ask special raw_string
+`,
+    `invalid`,
+`>> Sorry, I cannot find any Cryptocurrency Code matching “invalid”.
+>> context = now => @com.cryptonator.get_price => notify // {}
+>> ask special null
+`,
+    null],
 ];
 
 function handleCommand(almond, input) {


### PR DESCRIPTION
Lookup the text provided by the user in the database, by creating
an entity with null value and not-null display field. The subsequent
code concretizes the entity by looking up in the database.

Fixes #87