### PR TITLE
ParserClient: remove console.log entry

### DIFF
--- a/lib/parserclient.js
+++ b/lib/parserclient.js
@@ -21,8 +21,6 @@ module.exports = class ParserClient {
         this._baseUrl = (baseUrl || URL) + '/' + this._locale;
         this._prefs = prefs;
         this._platform = platform;
-
-        console.log('Using Almond-NNParser at ' + this._baseUrl);
     }
 
     onlineLearn(utterance, code, store = 'automatic') {


### PR DESCRIPTION
This entry is printed for every new ParserClient object (and thus
every new Almond object), which is quite a few in almond-cloud,
where we potentially run a lot of conversations at the same time --
especially for the anonymous user.