### PR TITLE
Add a hack to resolve app names locally

### DIFF
--- a/lib/legacy-dialogs/entity_lookup.js
+++ b/lib/legacy-dialogs/entity_lookup.js
@@ -75,6 +75,12 @@ async function lookupEntity(dlg, entityType, entityDisplay, idEntities) {
     if (idEntities.has(entityType))
         return getBestEntityMatch(entityDisplay, idEntities.get(entityType));
 
+    // HACK this should be made generic with some new Genie annotation
+    if (entityType === 'org.freedesktop:app_id' && dlg.manager.platform.hasCapability('app-launcher')) {
+        const candidates = await dlg.manager.platform.getCapability('app-launcher').listApps();
+        return getBestEntityMatch(entityDisplay, candidates);
+    }
+
     const { data:candidates, meta } = await dlg.manager.thingpedia.lookupEntity(entityType, entityDisplay);
 
     if (candidates.length === 0) {


### PR DESCRIPTION
App names (used by "open XXXX" command in Almond GNOME) are user-specific,
and using Thingpedia to resolve them is not very meaningful. Instead,
use a platform interface (which will implemented in Almond GNOME)
to resolve the entity name.

This allows me to "open google chrome" even though I have "Google Chrome (Unstable)"
installed.